### PR TITLE
MA-34: Added themes to settings page

### DIFF
--- a/Converters/ComparisonConverter.cs
+++ b/Converters/ComparisonConverter.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Avalonia.Data;
+using Avalonia.Data.Converters;
+
+namespace mystery_app.Converters;
+public class ComparisonConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+    {
+        return value?.Equals(parameter);
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+    {
+        return value?.Equals(true) == true ? parameter : BindingOperations.DoNothing;
+    }
+}

--- a/Messages/ChangeThemeMessage.cs
+++ b/Messages/ChangeThemeMessage.cs
@@ -1,0 +1,9 @@
+﻿using CommunityToolkit.Mvvm.Messaging.Messages;
+
+namespace mystery_app.Messages;
+public class ChangeThemeMessage : ValueChangedMessage<string>
+{
+    public ChangeThemeMessage(string value) : base(value)
+    { 
+    }
+}

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -13,11 +13,15 @@ public partial class MainWindowViewModel : ObservableObject
     private readonly Dictionary<string, ObservableObject> Pages;
     [ObservableProperty]
     private ObservableObject _currentPage;
+    [ObservableProperty]
+    private string _currentTheme;
 
     public MainWindowViewModel()
     {
+        _currentTheme = "Default";
+
         Pages = new Dictionary<string, ObservableObject>();
-        Pages.Add("Settings", new SettingsViewModel());
+        Pages.Add("Settings", new SettingsViewModel(_currentTheme));
         Pages.Add("MainContent", new MainContentViewModel());
         _currentPage = Pages["MainContent"];
 
@@ -26,6 +30,10 @@ public partial class MainWindowViewModel : ObservableObject
             Navigate(message.Value);
         });
 
+        WeakReferenceMessenger.Default.Register<ChangeThemeMessage>(this, (sender, message) =>
+        {
+            CurrentTheme = message.Value;
+        });
     }
 
     [RelayCommand]

--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -1,12 +1,15 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+﻿using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using mystery_app.Messages;
 
 namespace mystery_app.ViewModels;
-    
+
 public partial class SettingsViewModel : ObservableObject
 {
+
+    public ObservableCollection<string> Themes { get; set; }
 
     [ObservableProperty]
     private string _currentTheme;
@@ -14,6 +17,10 @@ public partial class SettingsViewModel : ObservableObject
     public SettingsViewModel(string currentTheme)
     {
         _currentTheme = currentTheme;
+        Themes = new ObservableCollection<string>();
+        Themes.Add("Default");
+        Themes.Add("Light");
+        Themes.Add("Dark");
     }
 
     [RelayCommand]

--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -8,8 +8,12 @@ namespace mystery_app.ViewModels;
 public partial class SettingsViewModel : ObservableObject
 {
 
-    public SettingsViewModel()
+    [ObservableProperty]
+    private string _currentTheme;
+
+    public SettingsViewModel(string currentTheme)
     {
+        _currentTheme = currentTheme;
     }
 
     [RelayCommand]
@@ -18,4 +22,10 @@ public partial class SettingsViewModel : ObservableObject
         WeakReferenceMessenger.Default.Send(new ChangePageMessage("MainContent"));
     }
 
+    [RelayCommand]
+    private void ChangeTheme(string theme)
+    {
+        CurrentTheme = theme;
+        WeakReferenceMessenger.Default.Send(new ChangeThemeMessage(CurrentTheme));
+    }
 }

--- a/Views/MainWindowView.axaml
+++ b/Views/MainWindowView.axaml
@@ -7,7 +7,8 @@
         x:Class="mystery_app.Views.MainWindowView"
         x:DataType="vm:MainWindowViewModel"
         Icon="/Assets/avalonia-logo.ico"
-        Title="mystery_app">
+        Title="mystery_app"
+		RequestedThemeVariant="{Binding CurrentTheme}">
 
     <Design.DataContext>
         <!-- This only sets the DataContext for the previewer in an IDE,

--- a/Views/SettingsView.axaml
+++ b/Views/SettingsView.axaml
@@ -5,15 +5,10 @@
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	xmlns:controls="clr-namespace:mystery_app.Controls"
 	xmlns:vm="clr-namespace:mystery_app.ViewModels"
-	xmlns:converters="clr-namespace:mystery_app.Converters"
 	mc:Ignorable="d"
 	x:Class="mystery_app.Views.SettingsView"
 	x:DataType="vm:SettingsViewModel">
 	
-	<UserControl.Resources>
-		<converters:ComparisonConverter x:Key="ComparisonConverter"/>
-	</UserControl.Resources>
-
 	<Design.DataContext>
 		<vm:SettingsViewModel />
 	</Design.DataContext>

--- a/Views/SettingsView.axaml
+++ b/Views/SettingsView.axaml
@@ -5,10 +5,15 @@
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	xmlns:controls="clr-namespace:mystery_app.Controls"
 	xmlns:vm="clr-namespace:mystery_app.ViewModels"
+	xmlns:converters="clr-namespace:mystery_app.Converters"
 	mc:Ignorable="d"
 	x:Class="mystery_app.Views.SettingsView"
-	x:DataType="vm:SettingsViewModel"
-	>
+	x:DataType="vm:SettingsViewModel">
+	
+	<UserControl.Resources>
+		<converters:ComparisonConverter x:Key="ComparisonConverter"/>
+	</UserControl.Resources>
+
 	<Design.DataContext>
 		<vm:SettingsViewModel />
 	</Design.DataContext>
@@ -18,5 +23,49 @@
 			<Button Command="{Binding GoToMainContentCommand}">Back</Button>
 			<TextBlock DockPanel.Dock="Top" Text="Settings"/>
 		</DockPanel>
+		<StackPanel>
+			<StackPanel>
+				<TextBlock Text="Change Theme"/>
+				<WrapPanel>
+					<RadioButton
+						Command="{Binding ChangeThemeCommand}"
+						CommandParameter="Default">
+						<RadioButton.IsChecked>
+							<Binding 
+								Path="CurrentTheme"
+								Converter="{StaticResource ComparisonConverter}"
+								ConverterParameter="Default">
+							</Binding>
+						</RadioButton.IsChecked>
+						Auto
+					</RadioButton>
+					<RadioButton 
+						Command="{Binding ChangeThemeCommand}"	 
+						CommandParameter="Light">
+						<RadioButton.IsChecked>
+							<Binding
+								Path="CurrentTheme"
+								Converter="{StaticResource ComparisonConverter}"
+								ConverterParameter="Light">
+							</Binding>
+						</RadioButton.IsChecked>
+						Light
+					</RadioButton>
+					<RadioButton
+						Command="{Binding ChangeThemeCommand}"
+						CommandParameter="Dark">
+						<RadioButton.IsChecked>
+							<Binding
+								Path="CurrentTheme"
+								Converter="{StaticResource ComparisonConverter}"
+								ConverterParameter="Dark">
+							</Binding>
+						</RadioButton.IsChecked>
+						Dark
+					</RadioButton>
+					<!--TODO: DRY, this code can be generated-->
+				</WrapPanel>
+			</StackPanel>
+		</StackPanel>
 	</DockPanel>
 </UserControl>

--- a/Views/SettingsView.axaml
+++ b/Views/SettingsView.axaml
@@ -26,45 +26,16 @@
 		<StackPanel>
 			<StackPanel>
 				<TextBlock Text="Change Theme"/>
-				<WrapPanel>
-					<RadioButton
-						Command="{Binding ChangeThemeCommand}"
-						CommandParameter="Default">
-						<RadioButton.IsChecked>
-							<Binding 
-								Path="CurrentTheme"
-								Converter="{StaticResource ComparisonConverter}"
-								ConverterParameter="Default">
-							</Binding>
-						</RadioButton.IsChecked>
-						Auto
-					</RadioButton>
-					<RadioButton 
-						Command="{Binding ChangeThemeCommand}"	 
-						CommandParameter="Light">
-						<RadioButton.IsChecked>
-							<Binding
-								Path="CurrentTheme"
-								Converter="{StaticResource ComparisonConverter}"
-								ConverterParameter="Light">
-							</Binding>
-						</RadioButton.IsChecked>
-						Light
-					</RadioButton>
-					<RadioButton
-						Command="{Binding ChangeThemeCommand}"
-						CommandParameter="Dark">
-						<RadioButton.IsChecked>
-							<Binding
-								Path="CurrentTheme"
-								Converter="{StaticResource ComparisonConverter}"
-								ConverterParameter="Dark">
-							</Binding>
-						</RadioButton.IsChecked>
-						Dark
-					</RadioButton>
-					<!--TODO: DRY, this code can be generated-->
-				</WrapPanel>
+				<ComboBox 
+					ItemsSource="{Binding Themes}"
+					SelectionChanged="ChangeThemeOnSelection"
+					SelectedItem="{Binding CurrentTheme}">
+					<ComboBox.ItemTemplate>
+						<DataTemplate>
+							<TextBlock Text="{Binding}"/>
+						</DataTemplate>
+					</ComboBox.ItemTemplate>
+				</ComboBox>
 			</StackPanel>
 		</StackPanel>
 	</DockPanel>

--- a/Views/SettingsView.axaml.cs
+++ b/Views/SettingsView.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using mystery_app.ViewModels;
 
 namespace mystery_app.Views;
 
@@ -7,5 +8,11 @@ public partial class SettingsView : UserControl
     public SettingsView()
     {
         InitializeComponent();
+    }
+
+    private void ChangeThemeOnSelection(object sender, SelectionChangedEventArgs e)
+    {
+        var theme = ((ComboBox)e.Source).SelectedItem.ToString();
+        ((SettingsViewModel)DataContext).ChangeThemeCommand.Execute(theme);
     }
 }


### PR DESCRIPTION
﻿ ### Summary
Allows users to choose theme (light, dark, default) from settings page
 ### Changes
- Added combo box to choose theme from in settings page
- Created unused comparison converter, will keep because it might be useful (previously used for radiobutton logic)