### PR TITLE
MA-20: Visualize edge creation

### DIFF
--- a/Controls/MovableUserControl.cs
+++ b/Controls/MovableUserControl.cs
@@ -25,7 +25,7 @@ public class MovableUserControl : UserControl
 
         if (hitElement is Control control)
         {
-            if (control == null || control.Tag == "Nonmovable") { return; }
+            if (control == null || control.Tag == "EdgeButton" || control.Tag == "Nonmovable") { return; }
         }
 
         _isPressed = true;

--- a/ViewModels/WorkspaceViewModel.cs
+++ b/ViewModels/WorkspaceViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using Avalonia;
 using Avalonia.Logging;
 using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -20,6 +21,12 @@ public partial class WorkspaceViewModel : ObservableObject
     [ObservableProperty]
     private IBrush _backgroundColor;
     BrushConverter _colorConverter;
+    [ObservableProperty]
+    private Point _selectedEdgeNodePosition;
+    [ObservableProperty]
+    private Point _cursorPosition;
+    [ObservableProperty]
+    private int _edgeVisualThickness;
 
     public WorkspaceViewModel(string backgroundColor)
     {

--- a/Views/NodeView.axaml
+++ b/Views/NodeView.axaml
@@ -25,7 +25,7 @@
 				DockPanel.Dock="Left"
 				Command="{Binding DeleteNodeCommand}">X</Button>
 			<Panel
-			Tag="Nonmovable"
+			Tag="EdgeButton"
 			Background="Blue"
 			Width="10"
 			Height="10"

--- a/Views/NodeView.axaml.cs
+++ b/Views/NodeView.axaml.cs
@@ -48,14 +48,14 @@ public partial class NodeView : MovableUserControl
     {
         var root = (TopLevel)((Visual)args.Source).GetVisualRoot();
         var rootCoordinates = args.GetPosition(root);
-        var hitElement = root.InputHitTest(rootCoordinates);
+        var hitElements = root.GetInputElementsAt(rootCoordinates);
 
-        if (hitElement is Control control)
+        foreach (var hitElement in hitElements)
         {
-            // TODO Find node, should improve this later
-            var node = control.Parent.Parent.Parent;
-            if (node == null || node.DataContext == null || node.DataContext is not NodeViewModel) { return; }
-            WeakReferenceMessenger.Default.Send(new ReleaseNodeEdgeMessage((NodeViewModel)node.DataContext));
+            if (hitElement is Control control && control.Tag == "EdgeButton")
+            {
+                WeakReferenceMessenger.Default.Send(new ReleaseNodeEdgeMessage((NodeViewModel)control.DataContext));
+            }
         }
     }
 

--- a/Views/WorkspaceView.axaml
+++ b/Views/WorkspaceView.axaml
@@ -108,6 +108,13 @@
 					</DataTemplate>
 				</ItemsControl.ItemTemplate>
 			</ItemsControl>
+			<Canvas>
+				<Line
+					StartPoint="{Binding SelectedEdgeNodePosition}"
+					EndPoint="{Binding CursorPosition}"
+					Stroke="Red"
+					StrokeThickness="{Binding EdgeVisualThickness}"/>
+			</Canvas>
 		</Panel>
 		
 	</SplitView>

--- a/Views/WorkspaceView.axaml.cs
+++ b/Views/WorkspaceView.axaml.cs
@@ -1,6 +1,9 @@
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
-using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+using mystery_app.Messages;
+using mystery_app.ViewModels;
 
 namespace mystery_app.Views;
 
@@ -9,6 +12,25 @@ public partial class WorkspaceView : UserControl
     public WorkspaceView()
     {
         InitializeComponent();
+        
+        WeakReferenceMessenger.Default.Register<SelectNodeEdgeMessage>(this, (sender, message) =>
+        {
+            ((WorkspaceViewModel)DataContext).SelectedEdgeNodePosition = message.Value.Position;
+            ((WorkspaceViewModel)DataContext).EdgeVisualThickness = 2;
+        });
+    }
+
+    protected override void OnPointerReleased(PointerReleasedEventArgs e)
+    {
+        ((WorkspaceViewModel)DataContext).EdgeVisualThickness = 0;
+        base.OnPointerReleased(e);
+    }
+
+    protected override void OnPointerMoved(PointerEventArgs e)
+    {
+        var currentPosition = e.GetPosition(this);
+        ((WorkspaceViewModel)DataContext).CursorPosition = currentPosition;
+        base.OnPointerMoved(e);
     }
 
     public void ToggleNotes(object sender, RoutedEventArgs args)


### PR DESCRIPTION
﻿ ### Summary
Visualizes edge when creating an edge for a node
 ### Changes
- Create red line to visualize edge on edge creation
- Updated logic to know if edge should be created
- Updated logic for movable node

TODO: Should make the new logic more organized (both edge creation and movable node)