### PR TITLE
MA-54: Fix bug with toggle mode

### DIFF
--- a/Constants/SettingsConstants.cs
+++ b/Constants/SettingsConstants.cs
@@ -16,9 +16,5 @@ public static class SettingsConstants
     public const string TRANSPARENT_WINDOW_STATE = "FullScreen";
 
     public static readonly ModeModel DEFAULT_MODE = new ModeModel("Default", DEFAULT_BACKGROUND_COLOR, true, 1, "Normal");
-    public static readonly ModeModel TRANSPARENT_MODE = new ToggleModeModel("Transparent", TRANSPARENT_BACKGROUND_COLOR, false, TRANSPARENT_WORKSPACE_OPACITY,TRANSPARENT_WINDOW_STATE);
-    public static readonly Collection<ModeModel> MODES = new Collection<ModeModel>()
-    {
-        TRANSPARENT_MODE
-    };
+    public static readonly ModeModel TRANSPARENT_MODE = new ModeModel("Transparent", TRANSPARENT_BACKGROUND_COLOR, false, TRANSPARENT_WORKSPACE_OPACITY,TRANSPARENT_WINDOW_STATE);
 }

--- a/Models/ToggleModeModel.cs
+++ b/Models/ToggleModeModel.cs
@@ -1,5 +1,7 @@
-﻿using Avalonia.Media;
+﻿using Avalonia.Controls;
+using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
+using DynamicData;
 using mystery_app.Constants;
 using mystery_app.Models;
 
@@ -23,6 +25,13 @@ public partial class ToggleModeModel : ModeModel
     {
         OffMode = offMode;
         OnMode = onMode;
+
+        // Settings default to off mode
+        Mode = OffMode.Mode;
+        Background = OffMode.Background;
+        ShowItems = OffMode.ShowItems;
+        WorkspaceOpacity = OffMode.WorkspaceOpacity;
+        WindowState = OffMode.WindowState;
     }
 
     [ObservableProperty]

--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -13,12 +13,13 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     private SharedSettingsModel _sharedSettings;
     [ObservableProperty]
-    private Collection<ModeModel> _modes = SettingsConstants.MODES;
+    private Collection<ModeModel> _modes = new Collection<ModeModel>();
 
     public SettingsViewModel(SharedSettingsModel sharedSettings)
     {
         SharedSettings = sharedSettings;
         Modes.Add(sharedSettings.UserModeModel);
+        Modes.Add(new ToggleModeModel(SettingsConstants.TRANSPARENT_MODE, sharedSettings.UserModeModel));
     }
 
     [RelayCommand]


### PR DESCRIPTION
﻿ ### Summary
Transparent toggle mode bugged out because new constructor wasn't used, updated it to be used
 ### Changes
- Settings creates transparent toggle mode in runtime
- Removed MODES constant
- Updated constructor for togglemode