### PR TITLE
MA-57: Update cursor position only when multiselecting or selecting a…

### DIFF
--- a/ViewModels/WorkspaceViewModel.cs
+++ b/ViewModels/WorkspaceViewModel.cs
@@ -46,6 +46,7 @@ public partial class WorkspaceViewModel : ObservableObject
                 EdgeThickness = EdgeConstants.THICKNESS;
                 SelectedNodeEdge = message.Value;
                 PressedPosition = new Point(nodeVMBase.NodeBase.PositionX, nodeVMBase.NodeBase.PositionY);
+                CursorPosition = new Point(nodeVMBase.NodeBase.PositionX, nodeVMBase.NodeBase.PositionY);
             }
         });
 

--- a/Views/WorkspaceView.axaml.cs
+++ b/Views/WorkspaceView.axaml.cs
@@ -8,6 +8,7 @@ using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
 using Avalonia.VisualTree;
 using CommunityToolkit.Mvvm.Messaging;
+using mystery_app.Constants;
 using mystery_app.Messages;
 using mystery_app.ViewModels;
 
@@ -46,6 +47,7 @@ public partial class WorkspaceView : UserControl
         {
             ((WorkspaceViewModel)DataContext).IsMultiSelecting = true;
             ((WorkspaceViewModel)DataContext).PressedPosition = e.GetPosition(this);
+            ((WorkspaceViewModel)DataContext).CursorPosition = e.GetPosition(this);
             ((WorkspaceViewModel)DataContext).MultiSelectThickness = 2;
         }
         base.OnPointerPressed(e);
@@ -53,7 +55,11 @@ public partial class WorkspaceView : UserControl
 
     protected override void OnPointerMoved(PointerEventArgs e)
     {
-        ((WorkspaceViewModel)DataContext).CursorPosition = e.GetPosition(this);
+        // Only update position if multiselecting or edge selecting
+        if (((WorkspaceViewModel)DataContext).IsMultiSelecting || ((WorkspaceViewModel)DataContext).SelectedNodeEdge != NodeConstants.NULL_NODEVIEWMODEL)
+        {
+            ((WorkspaceViewModel)DataContext).CursorPosition = e.GetPosition(this);
+        }
         base.OnPointerMoved(e);
     }
 


### PR DESCRIPTION
…n edge

﻿ ### Summary
Better to just leave the elements in there, so there's no creation cost. Initial issue this was to fix was having to re-render every time the cursor moves because when the cursor moves it updates the cursor position property. Instead, only update the property when moving the cursor and is multiselecting or selecting an edge (Only situations where the cursor position property needs to be updated
 ### Changes
- Only update cursor position of workspaceviewmodel when is multiselecting or selecting an edge