### PR TITLE
MA-67: Making settings look pretty

### DIFF
--- a/Constants/SettingsConstants.cs
+++ b/Constants/SettingsConstants.cs
@@ -1,12 +1,16 @@
 ﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 using mystery_app.Models;
 
 namespace mystery_app.Constants;
 
 public static class SettingsConstants
 {
+    // Constants for settings view
+    public static readonly ImmutableSolidColorBrush COLOR = new ImmutableSolidColorBrush(new Color(50, 255, 255, 255));
+
     // Theme Constants
     public static readonly Collection<string> THEMES = new Collection<string>() { "Default", "Light", "Dark" };
     public static readonly Color DEF_CLR = new Color(255, 255, 255, 255);

--- a/Constants/ToolBarConstants.cs
+++ b/Constants/ToolBarConstants.cs
@@ -6,7 +6,7 @@ namespace mystery_app.Constants;
 
 public static class ToolBarConstants
 {
-    public const double FONT_SIZE = 12;
+    public const double FONT_SIZE = 13;
     public static readonly ImmutableSolidColorBrush COLOR = new ImmutableSolidColorBrush(new Color(170, 150, 150, 150));
     public static readonly ImmutableSolidColorBrush BUTTON_BACKGROUND = new ImmutableSolidColorBrush(new Color(0, 0, 0, 0));
     public static readonly ImmutableSolidColorBrush BUTTON_TRANSPARENT = new ImmutableSolidColorBrush(new Color(30, 0, 0, 0));

--- a/Constants/ToolBarConstants.cs
+++ b/Constants/ToolBarConstants.cs
@@ -18,4 +18,6 @@ public static class ToolBarConstants
     public static readonly Thickness NORM_LPAD = new Thickness(12, 8, 12, 8);
     public static readonly Thickness MAX_RBTN_PAD = new Thickness(12, 16, 20, 8);
     public static readonly Thickness NORM_RBTN_PAD = new Thickness(12, 8, 12, 8);
+    public static readonly Thickness MAX_BBTN_PAD = new Thickness(12, 8, 12, 16);
+    public static readonly Thickness NORM_BBTN_PAD = new Thickness(12, 8, 12, 8);
 }

--- a/Models/SettingsModel.cs
+++ b/Models/SettingsModel.cs
@@ -8,8 +8,6 @@ public partial class SettingsModel : ObservableObject
     [ObservableProperty]
     private string _theme = SettingsConstants.THEMES[0];
     [ObservableProperty]
-    private bool _showNotes = true;
-    [ObservableProperty]
     private ModeModel _userModeModel = SettingsConstants.DEFAULT_MODE;
     [ObservableProperty]
     private ModeModel _modeModel;

--- a/ViewModels/MainContentViewModel.cs
+++ b/ViewModels/MainContentViewModel.cs
@@ -12,12 +12,16 @@ public partial class MainContentViewModel : ObservableObject
     [ObservableProperty]
     public WorkspaceViewModel _workspace;
     [ObservableProperty]
+    public SettingsViewModel _settings;
+    [ObservableProperty]
     private SettingsModel _sharedSettings;
 
     public MainContentViewModel(SettingsModel sharedSettings)
     {
         SharedSettings = sharedSettings;
         Workspace = new WorkspaceViewModel(sharedSettings);
+        Settings = new SettingsViewModel(sharedSettings);
+
     }
 
     [RelayCommand]

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -33,7 +33,6 @@ public partial class MainWindowViewModel : ObservableObject
         SharedSettings = LoadSettings();
 
         // Initialize available pages
-        Pages.Add(PageConstants.PAGE.Settings, new SettingsViewModel(SharedSettings));
         Pages.Add(PageConstants.PAGE.MainContent, new MainContentViewModel(SharedSettings));
         _currentPage = Pages[PageConstants.PAGE.MainContent];
 

--- a/Views/MainContentView.axaml
+++ b/Views/MainContentView.axaml
@@ -21,10 +21,10 @@
 		<Style Selector="Panel.Normal">
 			<Setter Property="Width" Value="{x:Static constants:ToolBarConstants.NORM_BORDER_WIDTH}"/>
 		</Style>
-		<Style Selector="Panel.BMaximized">
+		<Style Selector="DockPanel.BMaximized">
 			<Setter Property="Height" Value="{x:Static constants:ToolBarConstants.MAX_BORDER_WIDTH}"/>
 		</Style>
-		<Style Selector="Panel.BNormal">
+		<Style Selector="DockPanel.BNormal">
 			<Setter Property="Height" Value="{x:Static constants:ToolBarConstants.NORM_BORDER_WIDTH}"/>
 		</Style>
 		<Style Selector="ToggleButton">
@@ -36,15 +36,21 @@
 		<Style Selector="ToggleButton:pointerover /template/ ContentPresenter#PART_ContentPresenter">
 			<Setter Property="Background" Value="{x:Static constants:ToolBarConstants.BUTTON_TRANSPARENT}"/>
 		</Style>
-		<Style Selector="ToggleButton.Maximized">
+		<Style Selector="ToggleButton.RMaximized">
 			<Setter Property="Padding" Value="{x:Static constants:ToolBarConstants.MAX_RBTN_PAD}"/>
 		</Style>
-		<Style Selector="ToggleButton.Normal">
+		<Style Selector="ToggleButton.RNormal">
 			<Setter Property="Padding" Value="{x:Static constants:ToolBarConstants.NORM_RBTN_PAD}"/>
+		</Style>
+		<Style Selector="ToggleButton.MidMaximized">
+			<Setter Property="Padding" Value="{x:Static constants:ToolBarConstants.MAX_BBTN_PAD}"/>
+		</Style>
+		<Style Selector="ToggleButton.MidNormal">
+			<Setter Property="Padding" Value="{x:Static constants:ToolBarConstants.NORM_BBTN_PAD}"/>
 		</Style>
 	</UserControl.Styles>
 	
-	<DockPanel >
+	<DockPanel>
 		<DockPanel DockPanel.Dock="Top" IsVisible="{Binding SharedSettings.ModeModel.ShowItems}">
 			<DockPanel.Styles>
 				<Style Selector="PathIcon.Maximized">
@@ -140,12 +146,59 @@
 					Classes.MidMax="{Binding $parent[Window].WindowState, Converter={StaticResource WStateBoolConverter}, ConverterParameter=Maximized}"
 					Classes.MidNorm="{Binding $parent[Window].WindowState, Converter={StaticResource WStateBoolConverter}, ConverterParameter=Normal}"/>
 		</DockPanel>
-		<Panel Background="Transparent" DockPanel.Dock="Left"
+		<DockPanel Background="Transparent" DockPanel.Dock="Bottom"
 			   Classes.Maximized="{Binding $parent[Window].WindowState, Converter={StaticResource WStateBoolConverter}, ConverterParameter=Maximized}"
-			   Classes.Normal="{Binding $parent[Window].WindowState, Converter={StaticResource WStateBoolConverter}, ConverterParameter=Normal}"/>
-		<Panel Background="Transparent" DockPanel.Dock="Bottom"
-			   Classes.BMaximized="{Binding $parent[Window].WindowState, Converter={StaticResource WStateBoolConverter}, ConverterParameter=Maximized}"
-			   Classes.BNormal="{Binding $parent[Window].WindowState, Converter={StaticResource WStateBoolConverter}, ConverterParameter=Normal}"/>
+			   Classes.Normal="{Binding $parent[Window].WindowState, Converter={StaticResource WStateBoolConverter}, ConverterParameter=Normal}">
+			<Border Width="30" DockPanel.Dock="Left" Background="Transparent"
+					Classes.LeftMax="{Binding $parent[Window].WindowState, Converter={StaticResource WStateBoolConverter}, ConverterParameter=Maximized}"
+					Classes.LeftNorm="{Binding $parent[Window].WindowState, Converter={StaticResource WStateBoolConverter}, ConverterParameter=Normal}"/>
+			<ToggleButton Content="Settings"
+						  FontSize="{x:Static constants:ToolBarConstants.FONT_SIZE}"
+						  IsChecked="{Binding #SettingsSplitView.IsPaneOpen}"
+						  Margin="0"
+				  		  BorderThickness="0"
+						  CornerRadius="0"
+						  Classes.MidMaximized="{Binding $parent[Window].WindowState, Converter={StaticResource WStateBoolConverter}, ConverterParameter=Maximized}"
+						  Classes.MidNormal="{Binding $parent[Window].WindowState, Converter={StaticResource WStateBoolConverter}, ConverterParameter=Normal}"/>
+		</DockPanel>
+		<SplitView
+			DockPanel.Dock="Left"
+			Name="SettingsSplitView"
+			PanePlacement="Right"
+			DisplayMode="Inline"
+			OpenPaneLength="300"
+			Classes.Maximized="{Binding $parent[Window].WindowState, Converter={StaticResource WStateBoolConverter}, ConverterParameter=Maximized}"
+			Classes.Normal="{Binding $parent[Window].WindowState, Converter={StaticResource WStateBoolConverter}, ConverterParameter=Normal}">
+			<SplitView.PaneBackground>
+				<MultiBinding Converter="{StaticResource ARGBBrushConverter}">
+					<Binding Path="SharedSettings.ModeModel.A"/>
+					<Binding Path="SharedSettings.ModeModel.R"/>
+					<Binding Path="SharedSettings.ModeModel.G"/>
+					<Binding Path="SharedSettings.ModeModel.B"/>
+				</MultiBinding>
+			</SplitView.PaneBackground>
+
+			<SplitView.Pane>
+				<Border Padding="5" Background="{x:Static constants:ToolBarConstants.COLOR}">
+					<DockPanel>
+						<ToggleButton
+							Margin="5,5,5,5"
+							Padding="8"
+							IsChecked="{Binding #SettingsSplitView.IsPaneOpen}"
+							DockPanel.Dock="Top"
+							CornerRadius="10000"
+							HorizontalAlignment="Right">
+							<PathIcon Width="10" Height="10" Data="{StaticResource chevron_left_regular}"/>
+						</ToggleButton>
+						<views:SettingsView DataContext="{Binding Settings}"/>
+					</DockPanel>
+				</Border>
+			</SplitView.Pane>
+
+			<Panel Background="Transparent"
+				   Classes.Maximized="{Binding $parent[Window].WindowState, Converter={StaticResource WStateBoolConverter}, ConverterParameter=Maximized}"
+				   Classes.Normal="{Binding $parent[Window].WindowState, Converter={StaticResource WStateBoolConverter}, ConverterParameter=Normal}"/>
+		</SplitView>
 		<SplitView 
 			DockPanel.Dock="Right"
 			Name="NotesSplitView"
@@ -165,36 +218,33 @@
 
 			<SplitView.Pane>
 				<DockPanel Background="{x:Static constants:ToolBarConstants.COLOR}">
-					<DockPanel DockPanel.Dock="Top" Background="Transparent">
-						<ToggleButton
-							Margin="5,5,0,0"
-							Padding="8"
-							IsChecked="{Binding #NotesSplitView.IsPaneOpen}"
-							DockPanel.Dock="Left"
-							CornerRadius="10000">
-							<PathIcon Width="10" Height="10" Data="{StaticResource chevron_right_regular}"/>
-						</ToggleButton>
-					</DockPanel>
+					<ToggleButton
+						Margin="5,5,0,0"
+						Padding="8"
+						IsChecked="{Binding #NotesSplitView.IsPaneOpen}"
+						DockPanel.Dock="Top"
+						HorizontalAlignment="Left"
+						CornerRadius="10000">
+						<PathIcon Width="10" Height="10" Data="{StaticResource chevron_right_regular}"/>
+					</ToggleButton>
 					<TextBox Margin="5" BorderThickness="0"/>
 				</DockPanel>
 			</SplitView.Pane>
 
-			<DockPanel Background="Transparent"
-			   >
+			<DockPanel Background="Transparent">
 				<LayoutTransformControl>
 					<LayoutTransformControl.LayoutTransform>
 						<RotateTransform Angle="90"/>
 					</LayoutTransformControl.LayoutTransform>
 					<ToggleButton Content="Notes"
 								  FontSize="{x:Static constants:ToolBarConstants.FONT_SIZE}"
-								  IsVisible="{Binding SharedSettings.ShowNotes}"
 								  IsChecked="{Binding #NotesSplitView.IsPaneOpen}"
 								  Margin="0"
 								  BorderThickness="0"
 								  CornerRadius="0"
 								  HorizontalAlignment="Stretch"
-								  Classes.Maximized="{Binding $parent[Window].WindowState, Converter={StaticResource WStateBoolConverter}, ConverterParameter=Maximized}"
-								  Classes.Normal="{Binding $parent[Window].WindowState, Converter={StaticResource WStateBoolConverter}, ConverterParameter=Normal}">
+								  Classes.RMaximized="{Binding $parent[Window].WindowState, Converter={StaticResource WStateBoolConverter}, ConverterParameter=Maximized}"
+								  Classes.RNormal="{Binding $parent[Window].WindowState, Converter={StaticResource WStateBoolConverter}, ConverterParameter=Normal}">
 					</ToggleButton>
 				</LayoutTransformControl>
 			</DockPanel>

--- a/Views/MainContentView.axaml
+++ b/Views/MainContentView.axaml
@@ -65,6 +65,12 @@
 					<Setter Property="Background" Value="Transparent" />
 					<Setter Property="FontSize" Value="{x:Static constants:ToolBarConstants.FONT_SIZE}" />
 				</Style>
+				<Style Selector="ToggleButton">
+					<Setter Property="FontSize" Value="{x:Static constants:ToolBarConstants.FONT_SIZE}" />
+				</Style>
+				<Style Selector="MenuItem">
+					<Setter Property="FontSize" Value="{x:Static constants:ToolBarConstants.FONT_SIZE}" />
+				</Style>
 				<Style Selector="Button.MidMax">
 					<Setter Property="Padding" Value="{x:Static constants:ToolBarConstants.MAX_MBTN_PAD}"/>
 				</Style>
@@ -102,7 +108,6 @@
 						<MenuItem Header="New" Command="{Binding NewCommand}"/>
 						<MenuItem Header="Open" Click="Open"/>
 						<MenuItem Header="Save" Click="Save"/>
-						<MenuItem Header="Settings" Command="{Binding GoToSettingsCommand}"/>
 						<Separator/>
 						<MenuItem Header="Exit" Click="Exit"/>
 					</MenuFlyout>
@@ -166,7 +171,7 @@
 			Name="SettingsSplitView"
 			PanePlacement="Right"
 			DisplayMode="Inline"
-			OpenPaneLength="300"
+			OpenPaneLength="200"
 			Classes.Maximized="{Binding $parent[Window].WindowState, Converter={StaticResource WStateBoolConverter}, ConverterParameter=Maximized}"
 			Classes.Normal="{Binding $parent[Window].WindowState, Converter={StaticResource WStateBoolConverter}, ConverterParameter=Normal}">
 			<SplitView.PaneBackground>
@@ -227,7 +232,7 @@
 						CornerRadius="10000">
 						<PathIcon Width="10" Height="10" Data="{StaticResource chevron_right_regular}"/>
 					</ToggleButton>
-					<TextBox Margin="5" BorderThickness="0"/>
+					<TextBox Margin="5" BorderThickness="0" TextWrapping="Wrap"/>
 				</DockPanel>
 			</SplitView.Pane>
 

--- a/Views/SettingsView.axaml
+++ b/Views/SettingsView.axaml
@@ -8,14 +8,6 @@
 	mc:Ignorable="d"
 	x:Class="mystery_app.Views.SettingsView"
 	x:DataType="vm:SettingsViewModel">
-	<UserControl.Background>
-		<MultiBinding Converter="{StaticResource ARGBBrushConverter}">
-			<Binding Path="SharedSettings.ModeModel.A"/>
-			<Binding Path="SharedSettings.ModeModel.R"/>
-			<Binding Path="SharedSettings.ModeModel.G"/>
-			<Binding Path="SharedSettings.ModeModel.B"/>
-		</MultiBinding>
-	</UserControl.Background>
 	
 	<Design.DataContext>
 		<vm:SettingsViewModel />
@@ -31,52 +23,66 @@
 		</Style>
 	</UserControl.Styles>
 
-	<Border Margin="30" Padding="10" Background="Gray">
-		<DockPanel Background="Gray">
-			<DockPanel DockPanel.Dock="Top">
-				<Button Command="{Binding GoToMainContentCommand}">Back</Button>
-				<TextBlock DockPanel.Dock="Top" Text="Settings"/>
-			</DockPanel>
-			<StackPanel>
-				<StackPanel>
-					<TextBlock Text="Change Theme"/>
-					<ComboBox 
-						ItemsSource="{Binding Source={x:Static constants:SettingsConstants.THEMES}}"
-						SelectedItem="{Binding SharedSettings.Theme}">
-						<ComboBox.ItemTemplate>
-							<DataTemplate x:CompileBindings="False">
-								<TextBlock Text="{Binding}"/>
-							</DataTemplate>
-						</ComboBox.ItemTemplate>
-					</ComboBox>
-				</StackPanel>
-				<StackPanel>
-					<TextBlock Text="Change Background"/>
-					<ColorPicker 
-						HorizontalAlignment="Left"
-						Color="{Binding Background}"/>
-				</StackPanel>
-				<StackPanel>
-					<TextBlock Text="Show Notes"/>
-					<ToggleButton
-						Padding="2"
-						IsChecked="{Binding SharedSettings.ShowNotes}">
-						<Panel Height="10" Width="20"/>
-					</ToggleButton>
-				</StackPanel>
-				<StackPanel>
-					<TextBlock Text="Mode"/>
-					<ComboBox
-						ItemsSource="{Binding Modes}"
-						SelectedItem="{Binding SharedSettings.ModeModel}">
-						<ComboBox.ItemTemplate>
-							<DataTemplate>
-								<TextBlock Text="{Binding Name}"/>
-							</DataTemplate>
-						</ComboBox.ItemTemplate>
-					</ComboBox>
-				</StackPanel>
-			</StackPanel>
-		</DockPanel>
+	<Border Background="{x:Static constants:SettingsConstants.COLOR}" CornerRadius="8" Padding="20">
+		<Grid RowDefinitions="Auto,Auto,Auto,Auto" ColumnDefinitions="Auto,Auto" HorizontalAlignment="Center">
+			<Grid.Styles>
+				<Style Selector="Grid > TextBlock">
+					<Setter Property="HorizontalAlignment" Value="Right"/>
+					<Setter Property="VerticalAlignment" Value="Center"/>
+					<Setter Property="Margin" Value="0,0,2,0"/>
+				</Style>
+				<Style Selector="TextBlock">
+					<Setter Property="FontSize" Value="12"/>
+				</Style>
+				<Style Selector="ComboBox">
+					<Setter Property="MinHeight" Value="20"/>
+					<Setter Property="MaxHeight" Value="20"/>
+					<Setter Property="Padding" Value="6,0,0,0"/>
+					<Setter Property="BorderThickness" Value="0"/>
+					<Setter Property="VerticalAlignment" Value="Center"/>
+					<Setter Property="Margin" Value="2,0,0,0"/>
+				</Style>
+				<Style Selector="ComboBoxItem">
+					<Setter Property="MinHeight" Value="20"/>
+					<Setter Property="MaxHeight" Value="20"/>
+					<Setter Property="Padding" Value="6,0,0,0"/>
+					<Setter Property="BorderThickness" Value="0"/>
+					<Setter Property="VerticalAlignment" Value="Center"/>
+				</Style>
+				<Style Selector="Border.GridBorder">
+					<Setter Property="Height" Value="35"/>
+					<Setter Property="BorderThickness" Value="0"/>
+					<Setter Property="HorizontalAlignment" Value="Stretch"/>
+				</Style>
+			</Grid.Styles>
+
+			<Border Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Classes.GridBorder="true"/>
+			<TextBlock Text="Theme" Grid.Row="0" Grid.Column="0"/>
+			<ComboBox Grid.Row="0" Grid.Column="1"
+					  ItemsSource="{Binding Source={x:Static constants:SettingsConstants.THEMES}}"
+					  SelectedItem="{Binding SharedSettings.Theme}">
+				<ComboBox.ItemTemplate>
+					<DataTemplate x:CompileBindings="False">
+						<TextBlock Text="{Binding}"/>
+					</DataTemplate>
+				</ComboBox.ItemTemplate>
+			</ComboBox>
+
+			<Border Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Classes.GridBorder="true"/>
+			<TextBlock Text="Background" Grid.Row="1" Grid.Column="0"/>
+			<ColorPicker Grid.Row="1" Grid.Column="1"
+						 HorizontalAlignment="Left" VerticalAlignment="Center" Color="{Binding Background}" MaxHeight="20"/>
+				
+			<Border Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Classes.GridBorder="true"/>
+			<TextBlock Text="Mode" Grid.Row="2" Grid.Column="0"/>
+			<ComboBox Grid.Row="2" Grid.Column="1"
+					  ItemsSource="{Binding Modes}" SelectedItem="{Binding SharedSettings.ModeModel}">
+				<ComboBox.ItemTemplate>
+					<DataTemplate>
+						<TextBlock Text="{Binding Name}"/>
+					</DataTemplate>
+				</ComboBox.ItemTemplate>
+			</ComboBox>
+		</Grid>
 	</Border>
 </UserControl>

--- a/Views/SettingsView.axaml
+++ b/Views/SettingsView.axaml
@@ -32,7 +32,7 @@
 					<Setter Property="Margin" Value="0,0,2,0"/>
 				</Style>
 				<Style Selector="TextBlock">
-					<Setter Property="FontSize" Value="12"/>
+					<Setter Property="FontSize" Value="{x:Static constants:ToolBarConstants.FONT_SIZE}"/>
 				</Style>
 				<Style Selector="ComboBox">
 					<Setter Property="MinHeight" Value="20"/>


### PR DESCRIPTION
﻿ ### Summary
Moved settings from a page to an expandable section
 ### Changes
- Access settings from toolbar
- Settings is an expandable and is pretty now
- Removed 'Show Notes' setting since Notes button is non-intrusive
- Updated font size of options from 12 to 13
- Fixed wrapping for notes section