### PR TITLE
MA-70: Implement 'Save' functionality

### DIFF
--- a/ViewModels/MainContentViewModel.cs
+++ b/ViewModels/MainContentViewModel.cs
@@ -17,6 +17,8 @@ public partial class MainContentViewModel : ObservableObject
     public NotesModel _notes;
     [ObservableProperty]
     private SettingsModel _sharedSettings;
+    [ObservableProperty]
+    private string? _workspaceFileName;
 
     public MainContentViewModel(SettingsModel sharedSettings)
     {
@@ -24,6 +26,7 @@ public partial class MainContentViewModel : ObservableObject
         Workspace = new WorkspaceViewModel(sharedSettings);
         Settings = new SettingsViewModel(sharedSettings);
         Notes = new NotesModel();
+        WorkspaceFileName = null;
 
     }
 
@@ -44,5 +47,6 @@ public partial class MainContentViewModel : ObservableObject
 
         Workspace = new WorkspaceViewModel(SharedSettings);
         Notes = new NotesModel();
+        WorkspaceFileName = null;
     }
 }

--- a/Views/MainContentView.axaml
+++ b/Views/MainContentView.axaml
@@ -29,6 +29,7 @@
 					<MenuItem Header="New" Command="{Binding NewCommand}"/>
 					<MenuItem Header="Open" Click="Open"/>
 					<MenuItem Header="Save" Click="Save"/>
+					<MenuItem Header="Save As" Click="SaveAs"/>
 					<Separator/>
 					<MenuItem Header="Exit" Click="Exit"/>
 				</MenuFlyout>


### PR DESCRIPTION
﻿ ### Summary
If user is working on a workspace that is already saved, saving new progress by pressing the 'Save' button will not trigger dialog and will save automatically. If pressing 'Save' on a new workspace, it will trigger 'Save As' dialog.
 ### Changes
- Have content viewmodel store workspace file name
- Use workspace file name to determine whether to do save as or save
- updated open, new, save functions to support the new save functionality