### PR TITLE
MA-85: Right click create node creates node at cursor

### DIFF
--- a/ViewModels/WorkspaceViewModel.cs
+++ b/ViewModels/WorkspaceViewModel.cs
@@ -2,6 +2,8 @@
 using System.Collections.ObjectModel;
 using System.Linq;
 using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Logging;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
@@ -81,6 +83,16 @@ public partial class WorkspaceViewModel : ObservableObject
         {
             CopyNodes();
         });
+    }
+
+    [RelayCommand]
+    private void CreateNodeAtPress()
+    {
+        NodeModel nodeModel = new NodeModel(Nodes.Count);
+        nodeModel.PositionX = PressedPosition.X;
+        nodeModel.PositionY = PressedPosition.Y;
+        Nodes.Add(new NodeViewModel(nodeModel));
+
     }
 
     [RelayCommand]

--- a/ViewModels/WorkspaceViewModel.cs
+++ b/ViewModels/WorkspaceViewModel.cs
@@ -2,8 +2,6 @@
 using System.Collections.ObjectModel;
 using System.Linq;
 using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Logging;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;

--- a/Views/WorkspaceView.axaml
+++ b/Views/WorkspaceView.axaml
@@ -21,8 +21,8 @@
 	</UserControl.Background>
 
 	<UserControl.ContextMenu>
-		<ContextMenu>
-			<MenuItem Header="Create Node" Command="{Binding CreateNodeCommand}"/>
+		<ContextMenu x:Name="WorkspaceCM">
+			<MenuItem Header="Create Node" Command="{Binding CreateNodeAtPressCommand}"/>
 			<MenuItem Header="Paste" Command="{Binding PasteNodesCommand}"/>
 		</ContextMenu>
 	</UserControl.ContextMenu>

--- a/Views/WorkspaceView.axaml
+++ b/Views/WorkspaceView.axaml
@@ -21,7 +21,7 @@
 	</UserControl.Background>
 
 	<UserControl.ContextMenu>
-		<ContextMenu x:Name="WorkspaceCM">
+		<ContextMenu>
 			<MenuItem Header="Create Node" Command="{Binding CreateNodeAtPressCommand}"/>
 			<MenuItem Header="Paste" Command="{Binding PasteNodesCommand}"/>
 		</ContextMenu>

--- a/Views/WorkspaceView.axaml.cs
+++ b/Views/WorkspaceView.axaml.cs
@@ -43,6 +43,7 @@ public partial class WorkspaceView : UserControl
     // Start multiselect
     protected override void OnPointerPressed(PointerPressedEventArgs e)
     {
+        ((WorkspaceViewModel)DataContext).PressedPosition = e.GetPosition(this);
         // If not left click, return
         if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed) { return; }
 
@@ -52,7 +53,6 @@ public partial class WorkspaceView : UserControl
         if (((Control)hitElement).Parent == this)
         {
             ((WorkspaceViewModel)DataContext).IsMultiSelecting = true;
-            ((WorkspaceViewModel)DataContext).PressedPosition = e.GetPosition(this);
             ((WorkspaceViewModel)DataContext).CursorPosition = e.GetPosition(this);
             ((WorkspaceViewModel)DataContext).MultiSelectThickness = 2;
         }


### PR DESCRIPTION
﻿ ### Summary
Creating a node from the context menu creates the node where the context menu was made / pointer was last pressed
 ### Changes
- Record pointer press on any click type
- Use pointer press for node creation location when creating from context menu