### PR TITLE
MA-86: Create nodes from toolbar at center of screen

### DIFF
--- a/ViewModels/WorkspaceViewModel.cs
+++ b/ViewModels/WorkspaceViewModel.cs
@@ -2,6 +2,8 @@
 using System.Collections.ObjectModel;
 using System.Linq;
 using Avalonia;
+using Avalonia.Controls;
+using Avalonia.VisualTree;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
@@ -9,6 +11,7 @@ using DynamicData;
 using mystery_app.Constants;
 using mystery_app.Messages;
 using mystery_app.Models;
+using mystery_app.Views;
 
 namespace mystery_app.ViewModels;
 
@@ -86,11 +89,15 @@ public partial class WorkspaceViewModel : ObservableObject
     [RelayCommand]
     private void CreateNodeAtPress()
     {
-        NodeModel nodeModel = new NodeModel(Nodes.Count);
-        nodeModel.PositionX = PressedPosition.X;
-        nodeModel.PositionY = PressedPosition.Y;
-        Nodes.Add(new NodeViewModel(nodeModel));
+        CreateNodeAtPos(PressedPosition.X, PressedPosition.Y);
+    }
 
+    public void CreateNodeAtPos(double x, double y)
+    {
+        NodeModel nodeModel = new NodeModel(Nodes.Count);
+        nodeModel.PositionX = x;
+        nodeModel.PositionY = y;
+        Nodes.Add(new NodeViewModel(nodeModel));
     }
 
     [RelayCommand]

--- a/Views/MainContentView.axaml
+++ b/Views/MainContentView.axaml
@@ -47,7 +47,7 @@
 		<PathIcon Data="{StaticResource divider_short_regular}" DockPanel.Dock="Left" Width="10" Height="12"
 				  Classes.MaxMid="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Maximized}"
 				  Classes.NormMid="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Normal}"/>
-		<Button Template="{StaticResource MidTopBtn}" DockPanel.Dock="Left" Content="Create Node" Command="{Binding Workspace.CreateNodeCommand}"/>
+		<Button Template="{StaticResource MidTopBtn}" DockPanel.Dock="Left" Content="Create Node" Click="CreateNodeMidScreen"/>
 
 		<!-- Right side -->
 		<Button Template="{StaticResource RightTopBtn}" Click="Exit" DockPanel.Dock="Right">
@@ -140,5 +140,5 @@
 			</Border>
 		</SplitView.Pane>
 	</SplitView>
-	<views:WorkspaceView DataContext="{Binding Workspace}"/>
+	<views:WorkspaceView x:Name="CurrentWorkspace" DataContext="{Binding Workspace}"/>
 </DockPanel>

--- a/Views/MainContentView.axaml.cs
+++ b/Views/MainContentView.axaml.cs
@@ -12,6 +12,7 @@ using Avalonia.Interactivity;
 using Avalonia.Logging;
 using Avalonia.Media;
 using Avalonia.Platform.Storage;
+using Avalonia.VisualTree;
 using mystery_app.Constants;
 using mystery_app.Models;
 using mystery_app.ViewModels;
@@ -25,6 +26,7 @@ public partial class MainContentView : DockPanel
     private double _initialResizeX;
     private double _lastNotesLen;
     private SplitView _notesSplitView;
+    private WorkspaceView _workspace;
 
     JsonSerializerOptions options = new()
     {
@@ -38,6 +40,7 @@ public partial class MainContentView : DockPanel
     {
         InitializeComponent();
         _notesSplitView = this.FindControl<SplitView>("NotesSplitView");
+        _workspace = this.FindControl<WorkspaceView>("CurrentWorkspace");
     }
 
     protected async void Save(object sender, RoutedEventArgs e)
@@ -214,5 +217,13 @@ public partial class MainContentView : DockPanel
             double offsetX = _initialResizeX - currentPosition.X;
             ((MainContentViewModel)DataContext).Notes.PaneLength = Math.Min(ToolbarConstants.NOTES_PANE_MAX_LEN, Math.Max(ToolbarConstants.NOTES_PANE_MIN_LEN, _lastNotesLen + offsetX));
         }
+    }
+
+    protected void CreateNodeMidScreen(object sender, RoutedEventArgs e)
+    {
+        Logger.TryGet(LogEventLevel.Fatal, LogArea.Control)?.Log(this, _workspace.Bounds.ToString());
+        Point pos = (_workspace.Bounds.BottomRight - _workspace.Bounds.TopLeft) / 2 - (new Point(NodeConstants.MIN_WIDTH, NodeConstants.MIN_HEIGHT) / 2);
+
+        ((MainContentViewModel)DataContext).Workspace.CreateNodeAtPos(pos.X, pos.Y);
     }
 }


### PR DESCRIPTION
﻿ ### Summary
Nodes created from the toolbar appear at the middle of the screen
 ### Changes
- Updated method to create node to find middle of workspace and use it to place node
- Created method in workspace view model to create nodes at a specified position