### PR TITLE
MA-79: Removing unneeded code

### DIFF
--- a/Views/MainContentView.axaml.cs
+++ b/Views/MainContentView.axaml.cs
@@ -9,10 +9,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Input;
 using Avalonia.Interactivity;
-using Avalonia.Logging;
-using Avalonia.Media;
 using Avalonia.Platform.Storage;
-using Avalonia.VisualTree;
 using mystery_app.Constants;
 using mystery_app.Models;
 using mystery_app.ViewModels;
@@ -57,7 +54,6 @@ public partial class MainContentView : DockPanel
             }
             IStorageFolder directory = await TopLevel.GetTopLevel(this).StorageProvider.TryGetFolderFromPathAsync("./Workspaces");
             string path = directory.TryGetLocalPath() + "/" + ((MainContentViewModel)DataContext).WorkspaceFileName;
-            Logger.TryGet(LogEventLevel.Fatal, LogArea.Control)?.Log(this, path);
             IStorageFile file = await TopLevel.GetTopLevel(this).StorageProvider.TryGetFileFromPathAsync(path);
             if (file is not null)
             {
@@ -221,9 +217,7 @@ public partial class MainContentView : DockPanel
 
     protected void CreateNodeMidScreen(object sender, RoutedEventArgs e)
     {
-        Logger.TryGet(LogEventLevel.Fatal, LogArea.Control)?.Log(this, _workspace.Bounds.ToString());
         Point pos = (_workspace.Bounds.BottomRight - _workspace.Bounds.TopLeft) / 2 - (new Point(NodeConstants.MIN_WIDTH, NodeConstants.MIN_HEIGHT) / 2);
-
         ((MainContentViewModel)DataContext).Workspace.CreateNodeAtPos(pos.X, pos.Y);
     }
 }

--- a/Views/WorkspaceView.axaml
+++ b/Views/WorkspaceView.axaml
@@ -49,7 +49,7 @@
 			<ItemsControl.ItemTemplate>
 				<DataTemplate>
 					<views:InteractiveView DataContext="{Binding}">
-						<views:NodeView DataContext="{Binding}" Grid.Row="1" Canvas.ZIndex="{Binding NodeBase.ZIndex}"/>
+						<views:NodeView DataContext="{Binding}" Grid.Row="1"/>
 					</views:InteractiveView>
 				</DataTemplate>
 			</ItemsControl.ItemTemplate>


### PR DESCRIPTION
﻿ ### Summary
Not going to fix errors, more of warnings than errors. (Occurs with itemscontrol style, it tries to look for viewmodel, gives warnings before it finds it)
 ### Changes
- Removed logging from maincontentview
- Removed unneeded z index binding