### PR TITLE
MA-78: Shift / Ctrl + Left Click to multiselect

### DIFF
--- a/Messages/EditNodeMessage.cs
+++ b/Messages/EditNodeMessage.cs
@@ -1,0 +1,8 @@
+﻿using CommunityToolkit.Mvvm.Messaging.Messages;
+using mystery_app.ViewModels;
+
+namespace mystery_app.Messages;
+public class EditNodeMessage : ValueChangedMessage<NodeViewModelBase>
+{
+    public EditNodeMessage(NodeViewModelBase value) : base(value) { }
+}

--- a/Views/InteractiveView.axaml.cs
+++ b/Views/InteractiveView.axaml.cs
@@ -67,8 +67,7 @@ public partial class InteractiveView : Grid
             // If double click, make click through
             if (e.ClickCount >= 2)
             {
-                _vm.IsEdit = true;
-                WeakReferenceMessenger.Default.Send(new SelectNodeMessage(_vm));
+                WeakReferenceMessenger.Default.Send(new EditNodeMessage(_vm));
                 return;
             }
             WeakReferenceMessenger.Default.Send(new SelectNodeMessage(_vm));

--- a/Views/MainContentView.axaml.cs
+++ b/Views/MainContentView.axaml.cs
@@ -9,7 +9,6 @@ using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Input;
 using Avalonia.Interactivity;
-using Avalonia.Logging;
 using Avalonia.Platform.Storage;
 using mystery_app.Constants;
 using mystery_app.Models;
@@ -43,6 +42,7 @@ public partial class MainContentView : DockPanel
         if (Application.Current.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             ((TopLevel)desktop.MainWindow).AddHandler(InputElement.KeyDownEvent, HandleKeyDown, handledEventsToo: true);
+            ((TopLevel)desktop.MainWindow).AddHandler(InputElement.KeyUpEvent, HandleKeyUp, handledEventsToo: true);
         }
     }
 
@@ -257,6 +257,19 @@ public partial class MainContentView : DockPanel
             {
                 Save();
             }
+        }
+
+        if (e.KeyModifiers.HasFlag(KeyModifiers.Control) || e.KeyModifiers.HasFlag(KeyModifiers.Shift))
+        {
+            ((MainContentViewModel)DataContext).Workspace.MultiSelectHKDown = true;
+        }
+    }
+
+    private void HandleKeyUp(object sender, KeyEventArgs e)
+    {
+        if (!(e.KeyModifiers.HasFlag(KeyModifiers.Control) || e.KeyModifiers.HasFlag(KeyModifiers.Shift)))
+        {
+            ((MainContentViewModel)DataContext).Workspace.MultiSelectHKDown = false;
         }
     }
 }

--- a/Views/WorkspaceView.axaml.cs
+++ b/Views/WorkspaceView.axaml.cs
@@ -25,8 +25,7 @@ public partial class WorkspaceView : UserControl
         {
             if (args.Value.IsEdit)
             {
-                ((WorkspaceViewModel)DataContext).UpdateSelection(nodesToSelect: new ObservableCollection<NodeViewModelBase> { args.Value });
-                args.Value.IsEdit = true;
+                return;
             }
             else if (!((WorkspaceViewModel)DataContext).SelectedNodes.Contains(args.Value))
             {


### PR DESCRIPTION
﻿ ### Summary
Can multiselect by holding ctrl or left click
 ### Changes
- Updated node edit logic to use node edit message instead of jank select
- Added handling for key up and key down of ctrl / shift for multiselect
- Updated selection logic with shift / ctrl + left click logic