### PR TITLE
MA-87:  Clone nodes and edges in Copy

### DIFF
--- a/ViewModels/WorkspaceViewModel.cs
+++ b/ViewModels/WorkspaceViewModel.cs
@@ -144,11 +144,12 @@ public partial class WorkspaceViewModel : ObservableObject
         CopiedEdges = new ObservableCollection<EdgeViewModel>();
 
         // Copy nodes
-        HashSet<NodeModelBase> copiedNodeBases = new HashSet<NodeModelBase>();
+        IDictionary<NodeModelBase, NodeModelBase> refToClone = new Dictionary<NodeModelBase, NodeModelBase>();
         foreach (var node in SelectedNodes)
         {
-            CopiedNodes.Add(node);
-            copiedNodeBases.Add(node.NodeBase);
+            var clone = node.Clone();
+            CopiedNodes.Add(clone);
+            refToClone.Add(node.NodeBase, clone.NodeBase);
         }
        
         // Reorder nodes
@@ -157,9 +158,9 @@ public partial class WorkspaceViewModel : ObservableObject
         // Copy edges
         foreach (EdgeViewModel edgeViewModel in Edges)
         {
-            if (copiedNodeBases.Contains(edgeViewModel.Edge.FromNode) && copiedNodeBases.Contains(edgeViewModel.Edge.ToNode))
+            if (refToClone.ContainsKey(edgeViewModel.Edge.FromNode) && refToClone.ContainsKey(edgeViewModel.Edge.ToNode))
             {
-                CopiedEdges.Add(edgeViewModel);
+                CopiedEdges.Add(edgeViewModel.CloneWithNewNodes(refToClone[edgeViewModel.Edge.FromNode], refToClone[edgeViewModel.Edge.ToNode]));
             }
         }
     }


### PR DESCRIPTION
﻿ ### Summary
Copy has to contain only clones of nodes and edges, as changes to references will be reflected in pasted nodes
 ### Changes
- Clone nodes in Copy command
- Updated edge cloning logic in copy command (Similar to paste)