### PR TITLE
MA-62: Scale toolbar opacity with workspace opacity

### DIFF
--- a/App.axaml
+++ b/App.axaml
@@ -20,6 +20,8 @@
 			<customConverters:IsNotNullConverter x:Key="IsNotNullConverter"/>
 			<customConverters:ShowEdgeAddDescConverter x:Key="ShowEdgeAddDescConverter"/>
 			<customConverters:AddConverter x:Key="AddConverter"/>
+			<customConverters:BrushOpacityConverter x:Key="BrushOpacityConverter"/>
+			
 			<ResourceDictionary.MergedDictionaries>
 				<ResourceInclude Source="/Styles/ToolBarResources.axaml"/>
 				<ResourceInclude Source="/Styles/WorkspaceResources.axaml"/>

--- a/Converters/BrushOpacityConverter.cs
+++ b/Converters/BrushOpacityConverter.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+
+namespace mystery_app.Converters;
+public class BrushOpacityConverter : IValueConverter
+{
+    public static readonly BrushOpacityConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is byte opacity && parameter is SolidColorBrush brush)
+        {
+            double opacityPercent = opacity / 255.0;
+            Color color = brush.Color;
+            return new SolidColorBrush(new Color((byte)(color.A * opacityPercent), color.R, color.G, color.B));
+        }
+        return null;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return null;
+    }
+
+}

--- a/Views/MainContentView.axaml
+++ b/Views/MainContentView.axaml
@@ -8,7 +8,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     x:Class="mystery_app.Views.MainContentView"
     x:DataType="vm:MainContentViewModel"
-	Background="{StaticResource ToolBarColor}">
+	Background="{Binding SharedSettings.ModeModel.A, Converter={StaticResource BrushOpacityConverter}, ConverterParameter={StaticResource ToolBarColor}}">
 
     <Design.DataContext>
         <vm:MainContentViewModel/>
@@ -85,7 +85,7 @@
 		<UserControl Template="{StaticResource LeftBar}"/>
 
 		<SplitView.Pane>
-			<Border Padding="5" Background="{StaticResource ToolBarColor}">
+			<Border Padding="5" Background="{Binding SharedSettings.ModeModel.A, Converter={StaticResource BrushOpacityConverter}, ConverterParameter={StaticResource ToolBarColor}}">
 				<DockPanel>
 					<ToggleButton DockPanel.Dock="Top" Margin="5" Padding="8" CornerRadius="10000" HorizontalAlignment="Right"
 								  IsChecked="{Binding #SettingsSplitView.IsPaneOpen}">
@@ -120,7 +120,7 @@
 		</DockPanel>
 
 		<SplitView.Pane>
-			<Border Padding="0,5,5,5" Background="{StaticResource ToolBarColor}">
+			<Border Padding="0,5,5,5" Background="{Binding SharedSettings.ModeModel.A, Converter={StaticResource BrushOpacityConverter}, ConverterParameter={StaticResource ToolBarColor}}">
 				<DockPanel>
 					<Panel Cursor="LeftSide"
 						   Width="5"


### PR DESCRIPTION
﻿ ### Summary
Fix transparency issue where fully transparent background wouldn't be transparent. Had to scale toolbar opacity with workspace opacity
 ### Changes
- Created converter to change opacity with given bytes
- Implemented converter on toolbar background