### PR TITLE
MA-89: Updated toolbar menu items to show menuitems on hover after clicking one of them

### DIFF
--- a/Styles/ToolBarResources.axaml
+++ b/Styles/ToolBarResources.axaml
@@ -20,110 +20,10 @@
 	<Thickness x:Key="MaxTPad"> 12,16,12,8 </Thickness>
 	<Thickness x:Key="MaxTRPad"> 12,16,20,8 </Thickness>
 
-	<sys:Double x:Key="TogBtnHighlightSize"> 3 </sys:Double>
+	<sys:Double x:Key="TogBtnHighlightSize"> 4 </sys:Double>
 	<sys:Double x:Key="ToolBarFontSize"> 13 </sys:Double>
 
-	<ControlTemplate x:Key="MidTopBtn" TargetType="Button">
-		<Button 
-			Content="{TemplateBinding Content}" 
-			Command="{TemplateBinding Command}"
-			DockPanel.Dock="{TemplateBinding DockPanel.Dock}"
-			Flyout="{TemplateBinding Flyout}"
-			HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
-			VerticalAlignment="{TemplateBinding VerticalAlignment}"
-			Classes.Maximized="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Maximized}"
-			Classes.Normal="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Normal}">
-			<Button.Styles>
-				<Style Selector="Button.Maximized">
-					<Setter Property="Padding" Value="{StaticResource MaxTPad}"/>
-				</Style>
-				<Style Selector="Button.Normal">
-					<Setter Property="Padding" Value="{StaticResource NormPad}"/>
-				</Style>
-			</Button.Styles>
-		</Button>
-	</ControlTemplate>
-
-	<ControlTemplate x:Key="LeftSpacer" TargetType="UserControl">
-		<Border
-			Width="30"
-			DockPanel.Dock="Left"
-			Background="Transparent"
-			Classes.Maximized="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Maximized}"
-			Classes.Normal="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Normal}">
-			<Border.Styles>
-				<Style Selector="Border.Maximized">
-					<Setter Property="Padding" Value="{StaticResource MaxLPad}"/>
-				</Style>
-				<Style Selector="Border.Normal">
-					<Setter Property="Padding" Value="{StaticResource NormPad}"/>
-				</Style>
-			</Border.Styles>
-		</Border>
-	</ControlTemplate>
-
-	<ControlTemplate x:Key="RightBarSpacer" TargetType="UserControl">
-		<Border
-			Height="10"
-			DockPanel.Dock="{TemplateBinding DockPanel.Dock}"
-			Background="Transparent"
-			Classes.Maximized="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Maximized}"
-			Classes.Normal="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Normal}">
-			<Border.Styles>
-				<Style Selector="Border.Maximized">
-					<Setter Property="Padding" Value="{StaticResource MaxRPad}"/>
-				</Style>
-				<Style Selector="Border.Normal">
-					<Setter Property="Padding" Value="{StaticResource NormPad}"/>
-				</Style>
-			</Border.Styles>
-		</Border>
-	</ControlTemplate>
-
-	<ControlTemplate x:Key="LeftBarSpacer" TargetType="UserControl">
-		<Border
-			Height="10"
-			DockPanel.Dock="{TemplateBinding DockPanel.Dock}"
-			Background="Transparent"
-			Classes.Maximized="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Maximized}"
-			Classes.Normal="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Normal}">
-			<Border.Styles>
-				<Style Selector="Border.Maximized">
-					<Setter Property="Padding" Value="{StaticResource MaxLPad}"/>
-				</Style>
-				<Style Selector="Border.Normal">
-					<Setter Property="Padding" Value="{StaticResource NormPad}"/>
-				</Style>
-			</Border.Styles>
-		</Border>
-	</ControlTemplate>
-
-	<ControlTemplate x:Key="MidSpacer" TargetType="UserControl">
-		<Border
-			DockPanel.Dock="{TemplateBinding DockPanel.Dock}"
-			HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
-			VerticalAlignment="{TemplateBinding VerticalAlignment}"
-			Background="Transparent"/>
-	</ControlTemplate>
-
-	<ControlTemplate x:Key="RightTopBtn" TargetType="Button">
-		<Button
-			Content="{TemplateBinding Content}"
-			DockPanel.Dock="{TemplateBinding DockPanel.Dock}"
-			Classes.Maximized="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Maximized}"
-			Classes.Normal="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Normal}">
-			<Button.Styles>
-				<Style Selector="Button.Maximized">
-					<Setter Property="Padding" Value="{StaticResource MaxTRPad}"/>
-				</Style>
-				<Style Selector="Button.Normal">
-					<Setter Property="Padding" Value="{StaticResource NormPad}"/>
-				</Style>
-			</Button.Styles>
-		</Button>
-	</ControlTemplate>
-
-	<ControlTemplate x:Key="BotTogBtn" TargetType="ToggleButton">
+	<ControlTemplate x:Key="TogBtnTopHighlight" TargetType="ToggleButton">
 		<DockPanel>
 			<DockPanel.Styles>
 				<Style Selector="DockPanel">
@@ -134,27 +34,20 @@
 				</Style>
 				<Style Selector="DockPanel:focus">
 					<Setter Property="Opacity" Value="1"/>
-				</Style>
-				<Style Selector="TextBlock.Maximized">
-					<Setter Property="Padding" Value="{StaticResource MaxBPad}"/>
-				</Style>
-				<Style Selector="TextBlock.Normal">
-					<Setter Property="Padding" Value="{StaticResource NormPad}"/>
 				</Style>
 			</DockPanel.Styles>
 
 			<Border DockPanel.Dock="Top" Background="{StaticResource TogBtnHighlightColor}" Height="{StaticResource TogBtnHighlightSize}"/>
 			<TextBlock
+				Padding="12,5,12,5"
 				DockPanel.Dock="Bottom"
 				Text="{TemplateBinding Content}"
-				Background="Transparent"
-				Classes.Maximized="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Maximized}"
-				Classes.Normal="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Normal}">
+				Background="Transparent">
 			</TextBlock>
 		</DockPanel>
 	</ControlTemplate>
 
-	<ControlTemplate x:Key="RightTogBtn" TargetType="ToggleButton">
+	<ControlTemplate x:Key="TogBtnBotHighlight" TargetType="ToggleButton">
 		<DockPanel>
 			<DockPanel.Styles>
 				<Style Selector="DockPanel">
@@ -166,20 +59,14 @@
 				<Style Selector="DockPanel:focus">
 					<Setter Property="Opacity" Value="1"/>
 				</Style>
-				<Style Selector="TextBlock.Maximized">
-					<Setter Property="Padding" Value="{StaticResource MaxTPad}"/>
-				</Style>
-				<Style Selector="TextBlock.Normal">
-					<Setter Property="Padding" Value="{StaticResource NormPad}"/>
-				</Style>
 			</DockPanel.Styles>
 
 			<Border DockPanel.Dock="Bottom" Background="{StaticResource TogBtnHighlightColor}" Height="{StaticResource TogBtnHighlightSize}"/>
 			<TextBlock
+				Padding="12,5,12,5"
+				DockPanel.Dock="Bottom"
 				Text="{TemplateBinding Content}"
-				Background="Transparent"
-				Classes.Maximized="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Maximized}"
-				Classes.Normal="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Normal}">
+				Background="Transparent">
 			</TextBlock>
 		</DockPanel>
 	</ControlTemplate>

--- a/Styles/ToolBarStyles.axaml
+++ b/Styles/ToolBarStyles.axaml
@@ -18,11 +18,23 @@
 		<Setter Property="BorderThickness" Value="0" />
 		<Setter Property="CornerRadius" Value="0" />
 	</Style>
+
+	<!--Toggle Button Styling-->
+	<Style Selector="ToggleButton:unchecked /template/ ContentPresenter#PART_ContentPresenter">
+		<Setter Property="Background" Value="Transparent"/>
+		<Setter Property="Opacity" Value=".5"/>
+	</Style>
 	<Style Selector="ToggleButton:checked /template/ ContentPresenter#PART_ContentPresenter">
 		<Setter Property="Background" Value="Transparent"/>
+		<Setter Property="Opacity" Value="1"/>
 	</Style>
 	<Style Selector="ToggleButton:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-		<Setter Property="Background" Value="{StaticResource TogBtnHoverColor}"/>
+		<Setter Property="Background" Value="Transparent"/>
+		<Setter Property="Opacity" Value="1"/>
+	</Style>
+	<Style Selector="ToggleButton:pressed /template/ ContentPresenter#PART_ContentPresenter">
+		<Setter Property="Background" Value="Transparent"/>
+		<Setter Property="Opacity" Value="1"/>
 	</Style>
 	
 	<Style Selector="#TitleBar PathIcon.Max">
@@ -41,10 +53,27 @@
 		<Setter Property="Margin" Value="0,0,0,0"/>
 	</Style>
 
-	<Style Selector="Grid.Maximized">
-		<Setter Property="Margin" Value="13,5,5,5"/>
+	<Style Selector="DockPanel.TopNormal">
 	</Style>
-	<Style Selector="Grid.Normal">
+	<Style Selector="DockPanel.TopMax">
+		<Setter Property="Margin" Value="7,7,7,0"/>
+	</Style>
+
+	<Style Selector="DockPanel.BotNormal">
+	</Style>
+	<Style Selector="DockPanel.BotMax">
+		<Setter Property="Margin" Value="7,0,7,7"/>
+	</Style>
+
+	<Style Selector="Grid.LeftNormal">
 		<Setter Property="Margin" Value="5"/>
+	</Style>
+	<Style Selector="Grid.LeftMax">
+		<Setter Property="Margin" Value="12,5,5,5"/>
+	</Style>
+
+	<Style Selector="DockPanel.RightNormal"> </Style>
+	<Style Selector="DockPanel.RightMax">
+		<Setter Property="Margin" Value="0,0,7,0"/>
 	</Style>
 </Styles>

--- a/Views/MainContentView.axaml
+++ b/Views/MainContentView.axaml
@@ -23,27 +23,21 @@
 
 		<!-- Left side -->
 		<UserControl Template="{StaticResource LeftSpacer}" PointerPressed="MoveWindow"/>
-		<Button Template="{StaticResource MidTopBtn}" Content="File" DockPanel.Dock="Left">
-			<Button.Flyout>
-				<MenuFlyout Placement="BottomEdgeAlignedLeft">
-					<MenuItem Header="New" Command="{Binding NewCommand}"/>
-					<MenuItem Header="Open" Click="Open"/>
-					<MenuItem Header="Save" Click="SaveEvent"/>
-					<MenuItem Header="Save As" Click="SaveAsEvent"/>
-					<Separator/>
-					<MenuItem Header="Exit" Click="Exit"/>
-				</MenuFlyout>
-			</Button.Flyout>
-		</Button>
-		<Button Template="{StaticResource MidTopBtn}" Content="Edit" DockPanel.Dock="Left">
-			<Button.Flyout>
-				<MenuFlyout Placement="BottomEdgeAlignedLeft">
-					<MenuItem Header="Copy" Command="{Binding Workspace.CopyNodesCommand}"/>
-					<MenuItem Header="Paste" Command="{Binding Workspace.PasteNodesCommand}"/>
-					<MenuItem Header="Delete" Command="{Binding Workspace.DeleteSelectedItemsCommand}"/>
-				</MenuFlyout>
-			</Button.Flyout>
-		</Button>
+		<Menu>
+			<MenuItem Header="File">
+				<MenuItem Header="New" Command="{Binding NewCommand}"/>
+				<MenuItem Header="Open" Click="Open"/>
+				<MenuItem Header="Save" Click="SaveEvent"/>
+				<MenuItem Header="Save As" Click="SaveAsEvent"/>
+				<Separator/>
+				<MenuItem Header="Exit" Click="Exit"/>
+			</MenuItem>
+			<MenuItem Header="Edit">
+				<MenuItem Header="Copy" Command="{Binding Workspace.CopyNodesCommand}"/>
+				<MenuItem Header="Paste" Command="{Binding Workspace.PasteNodesCommand}"/>
+				<MenuItem Header="Delete" Command="{Binding Workspace.DeleteSelectedItemsCommand}"/>
+			</MenuItem>
+		</Menu>
 
 		<!-- Right side -->
 		<Button Template="{StaticResource RightTopBtn}" Click="Exit" DockPanel.Dock="Right">

--- a/Views/MainContentView.axaml
+++ b/Views/MainContentView.axaml
@@ -19,10 +19,12 @@
 	</DockPanel.Styles>
 	
 	<!-- Title / Top bar -->
-	<DockPanel x:Name="TitleBar" DockPanel.Dock="Top" IsVisible="{Binding SharedSettings.ModeModel.ShowItems}">
+	<DockPanel x:Name="TitleBar" DockPanel.Dock="Top" IsVisible="{Binding SharedSettings.ModeModel.ShowItems}"
+			   Classes.TopMax="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Maximized}"
+			   Classes.TopNormal="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Normal}">
 
 		<!-- Left side -->
-		<UserControl Template="{StaticResource LeftSpacer}" PointerPressed="MoveWindow"/>
+		<Border Width="30" Background="Transparent" PointerPressed="MoveWindow"/>
 		<Menu>
 			<MenuItem Header="File">
 				<MenuItem Header="New" Command="{Binding NewCommand}"/>
@@ -40,25 +42,26 @@
 		</Menu>
 
 		<!-- Right side -->
-		<Button Template="{StaticResource RightTopBtn}" Click="Exit" DockPanel.Dock="Right">
+		<Button Click="Exit" DockPanel.Dock="Right" Padding="12,0,12,0" VerticalAlignment="Stretch">
 			<PathIcon Width="10" Height="10" Data="{StaticResource dismiss_regular}"/>
 		</Button>
-		<Button Template="{StaticResource MidTopBtn}" Click="Maximize" DockPanel.Dock="Right">
+		<Button Click="Maximize" DockPanel.Dock="Right" Padding="12,0,12,0" VerticalAlignment="Stretch">
 			<PathIcon Width="10" Height="10"
-						Classes.Max="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Maximized}"
-						Classes.Norm="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Normal}">
-			</PathIcon>
+					  Classes.Max="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Maximized}"
+					  Classes.Norm="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Normal}"/>
 		</Button>
-		<Button Template="{StaticResource MidTopBtn}" Click="Minimize" DockPanel.Dock="Right">
+		<Button Click="Minimize" DockPanel.Dock="Right" Padding="12,0,12,0" VerticalAlignment="Stretch">
 			<PathIcon Width="10" Height="10" Data="{StaticResource line_horizontal_1_regular}"/>
 		</Button>
-		<UserControl Template="{StaticResource MidSpacer}" PointerPressed="MoveWindow" HorizontalAlignment="Stretch"/>
+		<UserControl Background="Transparent" PointerPressed="MoveWindow" HorizontalAlignment="Stretch"/>
 	</DockPanel>
 		
 	<!-- Bottom bar -->
-	<DockPanel x:Name="Bar" Background="Transparent" DockPanel.Dock="Bottom">
-		<UserControl Template="{StaticResource LeftSpacer}"/>
-		<ToggleButton Template="{StaticResource BotTogBtn}" Classes="BarBtn" Content="Settings" IsChecked="{Binding #SettingsSplitView.IsPaneOpen}"/>
+	<DockPanel x:Name="Bar" Background="Transparent" DockPanel.Dock="Bottom"
+			   Classes.BotMax="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Maximized}"
+			   Classes.BotNormal="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Normal}">
+		<Border Width="30" Background="Transparent" PointerPressed="MoveWindow"/>
+		<ToggleButton Template="{StaticResource TogBtnBotHighlight}" Content="Settings" IsChecked="{Binding #SettingsSplitView.IsPaneOpen}"/>
 	</DockPanel>
 		
 	<!-- Left bar -->
@@ -75,8 +78,8 @@
 		<DockPanel>
 			<Grid ColumnDefinitions="Auto" RowDefinitions="Auto,Auto"
 			Background="Transparent"
-			Classes.Maximized="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Maximized}"
-			Classes.Normal="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Normal}">
+			Classes.LeftMax="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Maximized}"
+			Classes.LeftNormal="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Normal}">
 				<Button Grid.Row="0" Grid.Column="0" Width="25" Height="25" Command="{Binding Workspace.ChangeClickModeCommand}" CommandParameter="Select">
 					<Button.Background>
 						<MultiBinding Converter="{StaticResource StrCheckBgConverter}">
@@ -126,14 +129,15 @@
 			</MultiBinding>
 		</SplitView.PaneBackground>
 
-		<DockPanel Background="Transparent">
-			<UserControl Template="{StaticResource RightBarSpacer}" DockPanel.Dock="Top"/>
+		<DockPanel Background="Transparent"
+				   Classes.RightMax="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Maximized}"
+				   Classes.RightNormal="{Binding $parent[Window].WindowState, Converter={StaticResource WSBoolConverter}, ConverterParameter=Normal}">
+			<Border Height="10" Background="Transparent" DockPanel.Dock="Top"/>
 			<LayoutTransformControl>
 				<LayoutTransformControl.LayoutTransform>
 					<RotateTransform Angle="90"/>
 				</LayoutTransformControl.LayoutTransform>
-				<ToggleButton Template="{StaticResource RightTogBtn}" Classes.BarBtn="true" Content="Notes" 
-							  IsChecked="{Binding #NotesSplitView.IsPaneOpen}"/>
+				<ToggleButton Template="{StaticResource TogBtnTopHighlight}" Content="Notes" IsChecked="{Binding #NotesSplitView.IsPaneOpen}"/>
 			</LayoutTransformControl>
 		</DockPanel>
 


### PR DESCRIPTION
﻿ ### Summary
Toolbar menu items show their sub menu items when hovered when one of them has already been clicked
 ### Changes
- Moved toolbar menu items into a menu parent
- Did a decent refactor on styling so padding is applied on borders instead of individual items (not sure why I did that originally)