### PR TITLE
MA-105: Move rendertransform related code to axaml

### DIFF
--- a/ViewModels/NodeViewModelBase.cs
+++ b/ViewModels/NodeViewModelBase.cs
@@ -50,7 +50,6 @@ public abstract partial class NodeViewModelBase : ObservableObject
                 {
                     NodeBase.PositionX += message.Value.X;
                     NodeBase.PositionY += message.Value.Y;
-                    control.RenderTransform = new TranslateTransform(NodeBase.PositionX, NodeBase.PositionY);
                 });
             }
         }

--- a/Views/InteractiveView.axaml
+++ b/Views/InteractiveView.axaml
@@ -21,6 +21,10 @@
 		</ContextMenu>
 	</Grid.ContextMenu>
 
+	<Grid.RenderTransform>
+		<TranslateTransform X="{Binding NodeBase.PositionX}" Y="{Binding NodeBase.PositionY}"/>
+	</Grid.RenderTransform>
+
 	<Design.DataContext>
 		<vm:NodeViewModelBase />
 	</Design.DataContext>

--- a/Views/InteractiveView.axaml.cs
+++ b/Views/InteractiveView.axaml.cs
@@ -11,7 +11,6 @@ using Avalonia.VisualTree;
 using Avalonia.LogicalTree;
 using mystery_app.Models;
 using System.Threading.Tasks;
-using Avalonia.Logging;
 
 namespace mystery_app.Views;
 
@@ -50,9 +49,6 @@ public partial class InteractiveView : Grid
                 AddHandler(DragDrop.DropEvent, DropImage);
 
             }
-
-            Logger.TryGet(LogEventLevel.Fatal, LogArea.Control)?.Log(this, _vm.NodeBase.PositionX.ToString() + " " + _vm.NodeBase.PositionY.ToString());
-            RenderTransform = new TranslateTransform(_vm.NodeBase.PositionX, _vm.NodeBase.PositionY);
         }
     }
 
@@ -146,7 +142,6 @@ public partial class InteractiveView : Grid
     {
         _vm.NodeBase.PositionX = offsetX;
         _vm.NodeBase.PositionY = offsetY;
-        RenderTransform = new TranslateTransform(offsetX, offsetY);
     }
 
     // On selecting node edge creation, tell workspace this node has been selected


### PR DESCRIPTION
﻿ ### Summary
Rendertransform can be set with a binding in axaml, do that instead of updating RenderTransform manually in codebehind
 ### Changes
- Moved rendertransform for interactive view to axaml