### PR TITLE
MA-104: Update edge visual logic

### DIFF
--- a/Constants/EdgeConstants.cs
+++ b/Constants/EdgeConstants.cs
@@ -4,7 +4,7 @@ namespace mystery_app.Constants;
 
 public static class EdgeConstants
 {
-    public const double THICKNESS = 2;
+    public const double DEFAULT_THICKNESS = 2;
     public const double CLICK_THICKNESS = 25;
     public static readonly Color COLOR = new Color(255, 255, 0, 0);
     public const byte A = 255;

--- a/Models/EdgeModel.cs
+++ b/Models/EdgeModel.cs
@@ -14,7 +14,7 @@ public partial class EdgeModel : ObservableObject
         FromNode = fromNode;
         ToNode = toNode;
         Description = null;
-        Thickness = EdgeConstants.THICKNESS;
+        Thickness = EdgeConstants.DEFAULT_THICKNESS;
         A = EdgeConstants.A;
         R = EdgeConstants.R;
         G = EdgeConstants.G;
@@ -25,7 +25,7 @@ public partial class EdgeModel : ObservableObject
         NodeModelBase fromNode, 
         NodeModelBase toNode, 
         string description, 
-        double thickness = EdgeConstants.THICKNESS, 
+        double thickness = EdgeConstants.DEFAULT_THICKNESS, 
         byte a=EdgeConstants.A, byte r=EdgeConstants.R, byte g=EdgeConstants.G, byte b=EdgeConstants.B)
     {
         FromNode = fromNode;

--- a/ViewModels/WorkspaceViewModel.cs
+++ b/ViewModels/WorkspaceViewModel.cs
@@ -33,6 +33,8 @@ public partial class WorkspaceViewModel : ObservableObject
     [ObservableProperty]
     private bool _isPanning;
     [ObservableProperty]
+    private bool _isEdging;
+    [ObservableProperty]
     private Point _PanPosition;
     [ObservableProperty]
     private double _scale = 1;
@@ -89,6 +91,7 @@ public partial class WorkspaceViewModel : ObservableObject
                 NodeToCreateEdge = nodeVMBase;
                 // Manually assign position to where pin is
                 CursorPosition = new Point(NodeToCreateEdge.NodeBase.PositionX + (NodeToCreateEdge.NodeBase.Width / 2), NodeToCreateEdge.NodeBase.PositionY + 11);
+                IsEdging = true;
             }
         });
 
@@ -96,7 +99,8 @@ public partial class WorkspaceViewModel : ObservableObject
         {
             var enteredNode = message.Value;
 
-            if (Nodes.Contains(enteredNode) 
+            if (enteredNode != NodeConstants.NULL_NODEVIEWMODEL
+                && Nodes.Contains(enteredNode) 
                 && Nodes.Contains(NodeToCreateEdge)
                 && !Equals(enteredNode, NodeToCreateEdge)
                 && !Edges.ContainsEdge(NodeToCreateEdge.NodeBase, enteredNode.NodeBase))
@@ -104,6 +108,7 @@ public partial class WorkspaceViewModel : ObservableObject
                 Edges.Add(new EdgeViewModel(new EdgeModel(NodeToCreateEdge.NodeBase, enteredNode.NodeBase)));
             }
             NodeToCreateEdge = NodeConstants.NULL_NODEVIEWMODEL;
+            IsEdging = false;
         });
 
         WeakReferenceMessenger.Default.Register<DeleteMessage>(this, (sender, message) =>

--- a/ViewModels/WorkspaceViewModel.cs
+++ b/ViewModels/WorkspaceViewModel.cs
@@ -87,7 +87,6 @@ public partial class WorkspaceViewModel : ObservableObject
         {
             if (message.Value is NodeViewModelBase nodeVMBase && Nodes.Contains(nodeVMBase))
             {
-                EdgeThickness = EdgeConstants.THICKNESS;
                 NodeToCreateEdge = nodeVMBase;
                 // Manually assign position to where pin is
                 CursorPosition = new Point(NodeToCreateEdge.NodeBase.PositionX + (NodeToCreateEdge.NodeBase.Width / 2), NodeToCreateEdge.NodeBase.PositionY + 11);

--- a/Views/InteractiveView.axaml.cs
+++ b/Views/InteractiveView.axaml.cs
@@ -164,6 +164,10 @@ public partial class InteractiveView : Grid
         {
             WeakReferenceMessenger.Default.Send(new ReleaseNodeEdgeMessage(vm));
         }
+        else
+        {
+            WeakReferenceMessenger.Default.Send(new ReleaseNodeEdgeMessage(NodeConstants.NULL_NODEVIEWMODEL));
+        }
     }
 
     // Handle dropping image

--- a/Views/MainContentView.axaml.cs
+++ b/Views/MainContentView.axaml.cs
@@ -363,7 +363,6 @@ public partial class MainContentView : DockPanel
     {
         WorkspaceViewModel context = ((MainContentViewModel)DataContext).Workspace;
         // Make lines disappear
-        context.EdgeThickness = 0;
         context.MultiSelectThickness = 0;
 
         // Multiselect

--- a/Views/WorkspaceView.axaml
+++ b/Views/WorkspaceView.axaml
@@ -89,7 +89,7 @@
 		<Canvas>
 			<Line
 				EndPoint="{Binding CursorPosition}"
-				StrokeThickness="{Binding EdgeThickness}"
+				StrokeThickness="{x:Static constants:EdgeConstants.DEFAULT_THICKNESS}"
 				IsHitTestVisible="False"
 				IsVisible="{Binding IsEdging}">
 				<Line.StartPoint>

--- a/Views/WorkspaceView.axaml
+++ b/Views/WorkspaceView.axaml
@@ -90,7 +90,8 @@
 			<Line
 				EndPoint="{Binding CursorPosition}"
 				StrokeThickness="{Binding EdgeThickness}"
-				IsHitTestVisible="False">
+				IsHitTestVisible="False"
+				IsVisible="{Binding IsEdging}">
 				<Line.StartPoint>
 					<MultiBinding Converter="{StaticResource EdgePosConverter}">
 						<Binding Path="NodeToCreateEdge.NodeBase.PositionX"/>


### PR DESCRIPTION
﻿ ### Summary
Change edge visual logic to use bool for visibility instead of adjusting stroke thickness for visibility
 ### Changes
- Set boolean whenever edging and use it for visibility
- Stop adjusting thickness whenever creating / releasing edge