### PR TITLE
MA-113

### DIFF
--- a/Styles/WorkspaceResources.axaml
+++ b/Styles/WorkspaceResources.axaml
@@ -13,6 +13,11 @@
 
 	<Color x:Key="HighlightColor">#FF88BBFF</Color>
 
+	<!-- Workspace Constants -->
+	<sys:Int32 x:Key="MaxWorkspaceWidth"> 100000 </sys:Int32>
+	<sys:Int32 x:Key="MaxWorkspaceHeight"> 100000 </sys:Int32>
+
+
 	<!-- Node Constants-->
 	<SolidColorBrush x:Key="NodeToggledColor" Color="#FFa58c64" />
 	<SolidColorBrush x:Key="NodeUntoggledColor" Color="#FFc8b98c" />
@@ -30,5 +35,6 @@
 	<sys:Double x:Key="ImageIconPct"> 0.75 </sys:Double>
 	<sys:Double x:Key="AddImageIconPct"> 0.1 </sys:Double>
 	<sys:Double x:Key="AddImageIconPaddingPct"> 0.4 </sys:Double>
+
 
 </ResourceDictionary>

--- a/Styles/WorkspaceResources.axaml
+++ b/Styles/WorkspaceResources.axaml
@@ -17,6 +17,9 @@
 	<sys:Int32 x:Key="MaxWorkspaceWidth"> 100000 </sys:Int32>
 	<sys:Int32 x:Key="MaxWorkspaceHeight"> 100000 </sys:Int32>
 
+	<sys:Double x:Key="MaxWorkspaceWidthDbl"> 100000 </sys:Double>
+	<sys:Double x:Key="MaxWorkspaceHeightDbl"> 100000 </sys:Double>
+
 
 	<!-- Node Constants-->
 	<SolidColorBrush x:Key="NodeToggledColor" Color="#FFa58c64" />

--- a/ViewModels/WorkspaceViewModel.cs
+++ b/ViewModels/WorkspaceViewModel.cs
@@ -126,9 +126,9 @@ public partial class WorkspaceViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private void CreateNodeAtPress()
+    private void CreateNodeAtCursor()
     {
-        CreateNodeAtPos(PressedPosition.X, PressedPosition.Y);
+        CreateNodeAtPos(CursorPosition.X, CursorPosition.Y);
     }
 
     public void CreateNodeAtPos(double x, double y)

--- a/Views/MainContentView.axaml
+++ b/Views/MainContentView.axaml
@@ -74,9 +74,9 @@
 			<TextBlock Text="{Binding Workspace.Scale, Converter={StaticResource PercentStringConverter}}" DockPanel.Dock="Right" VerticalAlignment="Center"/>
 			<PathIcon Data="{StaticResource full_screen_zoom_regular}" Width="16" Height="16" Margin="0,0,6,0" DockPanel.Dock="Right" HorizontalAlignment="Right" VerticalAlignment="Center"/>
 			<Border Width="30" Background="Transparent" DockPanel.Dock="Right"/>
-			<TextBox Text="{Binding Workspace.CanvasSizeY, Converter={StaticResource CanvasSizeConverter}, ConverterParameter=10000}" DockPanel.Dock="Right"/>
+			<TextBox Text="{Binding Workspace.CanvasSizeY, Converter={StaticResource CanvasSizeConverter}, ConverterParameter={StaticResource MaxWorkspaceWidth}}" DockPanel.Dock="Right"/>
 			<TextBlock Text=" x " DockPanel.Dock="Right" VerticalAlignment="Center"/>
-			<TextBox Text="{Binding Workspace.CanvasSizeX, Converter={StaticResource CanvasSizeConverter}, ConverterParameter=10000}" DockPanel.Dock="Right"/>
+			<TextBox Text="{Binding Workspace.CanvasSizeX, Converter={StaticResource CanvasSizeConverter}, ConverterParameter={StaticResource MaxWorkspaceWidth}}" DockPanel.Dock="Right"/>
 			<PathIcon Data="{StaticResource resize_regular}" Width="16" Height="16" Margin="0,0,8,0" DockPanel.Dock="Right" HorizontalAlignment="Right" VerticalAlignment="Center"/>
 		</DockPanel>
 	</DockPanel>
@@ -124,7 +124,7 @@
 		<SplitView.Pane>
 			<Border Padding="5" Background="{Binding SharedSettings.ModeModel.A, Converter={StaticResource BrushOpacityConverter}, ConverterParameter={StaticResource ToolBarColor}}">
 				<DockPanel>
-					<ToggleButton DockPanel.Dock="Top" Margin="5" Padding="8" CornerRadius="10000" HorizontalAlignment="Right"
+					<ToggleButton DockPanel.Dock="Top" Margin="5" Padding="8" CornerRadius="10" HorizontalAlignment="Right"
 								  IsChecked="{Binding #SettingsSplitView.IsPaneOpen}">
 						<PathIcon Width="10" Height="10" Data="{StaticResource chevron_left_regular}"/>
 					</ToggleButton>
@@ -183,7 +183,7 @@
 						   PointerReleased="ResizePointerReleased"
 						   PointerMoved="ResizePointerMoved"/>
 
-					<ToggleButton DockPanel.Dock="Top" Margin="5" Padding="8" CornerRadius="10000" HorizontalAlignment="Left"
+					<ToggleButton DockPanel.Dock="Top" Margin="5" Padding="8" CornerRadius="10" HorizontalAlignment="Left"
 								  IsChecked="{Binding #NotesSplitView.IsPaneOpen}">
 						<PathIcon Width="10" Height="10" Data="{StaticResource chevron_right_regular}"/>
 					</ToggleButton>

--- a/Views/WorkspaceSettingsView.axaml
+++ b/Views/WorkspaceSettingsView.axaml
@@ -69,9 +69,9 @@
 			
 			<TextBlock Text="Workspace Size" TextWrapping="Wrap" Grid.Row="0" Grid.Column="0" TextAlignment="Right"/>
 			<StackPanel Orientation="Horizontal" Grid.Row="0" Grid.Column="1">
-				<TextBox Text="{Binding WorkspaceSizeX, Converter={StaticResource CanvasSizeConverter}, ConverterParameter=10000}"/>
+				<TextBox Text="{Binding WorkspaceSizeX, Converter={StaticResource CanvasSizeConverter}, ConverterParameter={StaticResource MaxWorkspaceWidth}}"/>
 				<TextBlock Text=" x " VerticalAlignment="Center" FontSize="{StaticResource ToolBarFontSize}"/>
-				<TextBox Text="{Binding WorkspaceSizeY, Converter={StaticResource CanvasSizeConverter}, ConverterParameter=10000}"/>
+				<TextBox Text="{Binding WorkspaceSizeY, Converter={StaticResource CanvasSizeConverter}, ConverterParameter={StaticResource MaxWorkspaceHeight}}"/>
 			</StackPanel>
 		</Grid>
 	</StackPanel>

--- a/Views/WorkspaceView.axaml
+++ b/Views/WorkspaceView.axaml
@@ -26,7 +26,7 @@
 
 	<UserControl.ContextMenu>
 		<ContextMenu>
-			<MenuItem Header="Create Node" Command="{Binding CreateNodeAtPressCommand}"/>
+			<MenuItem Header="Create Node" Command="{Binding CreateNodeAtCursorCommand}"/>
 			<MenuItem Header="Paste" Command="{Binding PasteNodesCommand}"/>
 		</ContextMenu>
 	</UserControl.ContextMenu>
@@ -42,7 +42,7 @@
         <vm:WorkspaceViewModel />
     </Design.DataContext>
 
-	<Panel>
+	<Panel Width="{StaticResource MaxWorkspaceWidthDbl}" Height="{StaticResource MaxWorkspaceHeightDbl}" x:Name="WorkspaceCanvas">
 		<Image asyncImageLoader:ImageLoader.Source="{Binding WorkspaceImagePath.Path}"/>
 		<Border x:Name="VisualCanvas" Width="{Binding CanvasSizeX}" Height="{Binding CanvasSizeY}" Background="White" HorizontalAlignment="Center" VerticalAlignment="Center" CornerRadius="8" IsHitTestVisible="False">
 			<Image asyncImageLoader:ImageLoader.Source="{Binding CanvasImagePath.Path}"/>


### PR DESCRIPTION
﻿ ### Summary
Resizing workspace would move all the objects within it because the panel containing the nodes would resize with the workspace and move the origin (since it is centered). Instead, have that panel have a static width and height so resizing the workspace doesn't resize the panel
 ### Changes
- Set panel containing nodes to always have max width and height of workspace