### PR TITLE
MA-175: Log image setting

### DIFF
--- a/Messages/OpenImageDialogMessage.cs
+++ b/Messages/OpenImageDialogMessage.cs
@@ -1,0 +1,8 @@
+﻿using CommunityToolkit.Mvvm.Messaging.Messages;
+using dboard.ViewModels;
+
+namespace dboard.Messages;
+public class OpenImageDialogMessage : ValueChangedMessage<NodeViewModelBase>
+{
+    public OpenImageDialogMessage(NodeViewModelBase value) : base(value) { }
+}

--- a/Messages/SetImageMessage.cs
+++ b/Messages/SetImageMessage.cs
@@ -1,8 +1,9 @@
-﻿using CommunityToolkit.Mvvm.Messaging.Messages;
+﻿using System;
+using CommunityToolkit.Mvvm.Messaging.Messages;
 using dboard.ViewModels;
 
 namespace dboard.Messages;
-public class SetImageMessage : ValueChangedMessage<NodeViewModelBase>
+public class SetImageMessage : ValueChangedMessage<Tuple<NodeViewModelBase, string?>>
 {
-    public SetImageMessage(NodeViewModelBase value) : base(value) { }
+    public SetImageMessage(Tuple<NodeViewModelBase, string?> value) : base(value) { }
 }

--- a/ViewModels/NodeViewModelBase.cs
+++ b/ViewModels/NodeViewModelBase.cs
@@ -38,9 +38,9 @@ public abstract partial class NodeViewModelBase : ObservableObject
     }
 
     [RelayCommand(CanExecute = nameof(NodeBaseHasImagePathField))]
-    private void SetImage()
+    private void OpenImageDialog()
     {
-        WeakReferenceMessenger.Default.Send(new SetImageMessage(this));
+        WeakReferenceMessenger.Default.Send(new OpenImageDialogMessage(this));
     }
 
     public abstract NodeViewModelBase Clone();

--- a/Views/InteractiveView.axaml
+++ b/Views/InteractiveView.axaml
@@ -16,7 +16,7 @@
 
 	<Grid.ContextMenu>
 		<ContextMenu>
-			<MenuItem Header="Set Image" Command="{Binding SetImageCommand}"/>
+			<MenuItem Header="Set Image" Command="{Binding OpenImageDialogCommand}"/>
 			<MenuItem Header="Copy" Command="{Binding CopyNodeCommand}"/>
 			<MenuItem Header="Delete" Command="{Binding DeleteNodeCommand}"/>
 		</ContextMenu>
@@ -42,7 +42,7 @@
 				RowDefinitions="Auto,*,Auto">
 				<Grid.ContextMenu>
 					<ContextMenu>
-						<MenuItem Header="Set Image" Command="{Binding SetImageCommand}"/>
+						<MenuItem Header="Set Image" Command="{Binding OpenImageDialogCommand}"/>
 						<MenuItem Header="Copy" Command="{Binding CopyNodeCommand}"/>
 						<MenuItem Header="Delete" Command="{Binding DeleteNodeCommand}"/>
 					</ContextMenu>

--- a/Views/InteractiveView.axaml.cs
+++ b/Views/InteractiveView.axaml.cs
@@ -180,8 +180,8 @@ public partial class InteractiveView : Grid
             NodeModel node = vm.Node;
             if (e.Data.GetText() is string url && _IsImage(e.Data.GetText()))
             {
-                WeakReferenceMessenger.Default.Send(new LogActionMessage(new EditNodeActionModel(vm)));
-                node.ImagePath = e.Data.GetText();
+                Tuple<NodeViewModelBase, string?> nodeAndImagePath = Tuple.Create((NodeViewModelBase)vm, e.Data.GetText());
+                WeakReferenceMessenger.Default.Send(new SetImageMessage(nodeAndImagePath));
             }
             else if (e.Data.GetFileNames() is { } fileNames && fileNames is not null)
             {
@@ -189,8 +189,8 @@ public partial class InteractiveView : Grid
                 {
                     if (_IsImage(file))
                     {
-                        WeakReferenceMessenger.Default.Send(new LogActionMessage(new EditNodeActionModel(vm)));
-                        node.ImagePath = file;
+                        Tuple<NodeViewModelBase, string?> nodeAndImagePath = Tuple.Create((NodeViewModelBase)vm, file);
+                        WeakReferenceMessenger.Default.Send(new SetImageMessage(nodeAndImagePath));
                     }
                 }
             }

--- a/Views/WorkspaceView.axaml.cs
+++ b/Views/WorkspaceView.axaml.cs
@@ -35,11 +35,18 @@ public partial class WorkspaceView : UserControl
 
         WeakReferenceMessenger.Default.Register<SetImageMessage>(this, (sender, message) =>
         {
-            SetImage(message.Value);
+            NodeViewModelBase nodeViewModel = message.Value.Item1;
+            string? filePath = message.Value.Item2;
+            SetImage(nodeViewModel, filePath);
+        });
+
+        WeakReferenceMessenger.Default.Register<OpenImageDialogMessage>(this, (sender, message) =>
+        {
+            OpenImageDialog(message.Value);
         });
     }
 
-    public async void SetImage(NodeViewModelBase nodeViewModel)
+    public async void OpenImageDialog(NodeViewModelBase nodeViewModel)
     {
         var files = await TopLevel.GetTopLevel(this).StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
         {
@@ -49,11 +56,16 @@ public partial class WorkspaceView : UserControl
 
         if (files.Count == 1)
         {
-            if (nodeViewModel.NodeBase.GetType().GetProperty("ImagePath") is PropertyInfo property)
-            {
-                WeakReferenceMessenger.Default.Send(new LogActionMessage(new EditNodeActionModel(nodeViewModel)));
-                property.SetValue(nodeViewModel.NodeBase, files[0].Path.LocalPath, null);
-            }
+            SetImage(nodeViewModel, files[0].Path.LocalPath);
+        }
+    }
+
+    private void SetImage(NodeViewModelBase nodeViewModel, string? filePath)
+    {
+        if (nodeViewModel.NodeBase.GetType().GetProperty("ImagePath") is PropertyInfo property)
+        {
+            WeakReferenceMessenger.Default.Send(new LogActionMessage(new EditNodeActionModel(nodeViewModel)));
+            property.SetValue(nodeViewModel.NodeBase, filePath, null);
         }
     }
 }


### PR DESCRIPTION
﻿ ### Summary
Logs everywhere where an image can be set. In the future we may want to observe the property and log it that way, so logging is automatically there even when new nodes are made
 ### Changes
- Created messages for opening the message dialog and a message to handle setting an image
- Centralized image setting to a single method in the workspace
- Logging added to everywhere an image can be set for an node